### PR TITLE
Add KidBank package with improved structure and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
-# kidbank
-reward banking app for kids
+# KidBank
+
+KidBank is a small, well-structured Python package for managing a reward-based
+banking system for children. It models accounts, transactions, savings goals,
+and rewards in an easy-to-read and fully tested code base.
+
+## Features
+
+- **Account management** – create accounts, deposit allowances, withdraw funds,
+  and transfer money between siblings.
+- **Reward tracking** – redeem rewards and keep a history of what was earned.
+- **Savings goals** – define goals, contribute towards them, and monitor
+  progress with percentage calculations.
+- **Comprehensive statements** – generate readable account summaries that list
+  recent activity, goals, and rewards.
+- **Test coverage** – unit tests exercise the core behaviours to keep the
+  system reliable.
+
+## Project structure
+
+```
+src/
+  kidbank/
+    __init__.py      # Public package exports
+    account.py       # Core account logic and statement generation
+    exceptions.py    # Custom exception hierarchy
+    models.py        # Dataclasses for transactions, rewards, and goals
+    money.py         # Helpers for working with monetary values
+    service.py       # Facade for working with multiple accounts
+pytest.ini           # Configures pytest to use the src layout
+tests/
+  test_account.py    # Behavioural tests for individual accounts
+  test_service.py    # Integration tests for the KidBank service
+```
+
+## Getting started
+
+1. Ensure you have Python 3.9 or newer available.
+2. Install the development dependencies (only `pytest` is required) if you want
+   to run the test suite.
+
+## Usage example
+
+```python
+from kidbank import KidBank
+
+bank = KidBank()
+ava = bank.create_account("Ava", starting_balance=10)
+bank.deposit("Ava", 5, description="Weekly chores")
+
+bank.add_goal("Ava", name="Lego set", target_amount=40)
+bank.contribute_to_goal("Ava", name="Lego set", amount=12.5)
+
+bank.redeem_reward("Ava", name="Movie night", cost=5)
+
+print(ava.generate_statement())
+```
+
+## Running the tests
+
+```bash
+python -m pytest
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/kidbank/__init__.py
+++ b/src/kidbank/__init__.py
@@ -1,0 +1,26 @@
+"""KidBank package for managing reward-based banking for children."""
+
+from .account import Account
+from .exceptions import (
+    AccountNotFoundError,
+    DuplicateAccountError,
+    GoalNotFoundError,
+    InsufficientFundsError,
+    KidBankError,
+)
+from .models import Goal, Reward, Transaction, TransactionType
+from .service import KidBank
+
+__all__ = [
+    "Account",
+    "KidBank",
+    "Goal",
+    "Reward",
+    "Transaction",
+    "TransactionType",
+    "KidBankError",
+    "AccountNotFoundError",
+    "DuplicateAccountError",
+    "GoalNotFoundError",
+    "InsufficientFundsError",
+]

--- a/src/kidbank/account.py
+++ b/src/kidbank/account.py
@@ -1,0 +1,210 @@
+"""Account object encapsulating business logic for the KidBank application."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Tuple
+
+from .exceptions import GoalNotFoundError, InsufficientFundsError
+from .models import Goal, Reward, Transaction, TransactionType
+from .money import AmountLike, format_currency, require_positive, to_decimal
+
+
+class Account:
+    """Represents a child's account in the KidBank system."""
+
+    __slots__ = ("child_name", "_balance", "_transactions", "_goals", "_rewards")
+
+    def __init__(self, child_name: str, *, starting_balance: AmountLike = 0) -> None:
+        self.child_name = child_name
+        starting_value = to_decimal(starting_balance)
+        require_positive(starting_value, allow_zero=True)
+        self._balance: Decimal = starting_value
+        self._transactions: list[Transaction] = []
+        self._goals: dict[str, Goal] = {}
+        self._rewards: list[Reward] = []
+
+        if self._balance > Decimal("0"):
+            self._log_transaction(
+                self._balance,
+                TransactionType.DEPOSIT,
+                "Starting balance",
+            )
+
+    @property
+    def balance(self) -> Decimal:
+        """Return the current account balance."""
+
+        return self._balance
+
+    @property
+    def transactions(self) -> Tuple[Transaction, ...]:
+        """Return an immutable view of the transaction history."""
+
+        return tuple(self._transactions)
+
+    @property
+    def goals(self) -> Tuple[Goal, ...]:
+        """Return an immutable view of the savings goals."""
+
+        return tuple(self._goals.values())
+
+    @property
+    def rewards(self) -> Tuple[Reward, ...]:
+        """Return an immutable view of redeemed rewards."""
+
+        return tuple(self._rewards)
+
+    def deposit(self, amount: AmountLike, description: str = "Deposit") -> Transaction:
+        """Add money to the account."""
+
+        value = to_decimal(amount)
+        require_positive(value)
+        self._balance += value
+        return self._log_transaction(value, TransactionType.DEPOSIT, description)
+
+    def withdraw(self, amount: AmountLike, description: str = "Withdrawal") -> Transaction:
+        """Remove money from the account if sufficient funds are available."""
+
+        value = to_decimal(amount)
+        require_positive(value)
+        self._ensure_sufficient_funds(value)
+        self._balance -= value
+        return self._log_transaction(value, TransactionType.WITHDRAWAL, description)
+
+    def redeem_reward(self, name: str, cost: AmountLike, description: str = "") -> Reward:
+        """Redeem a reward by deducting its cost from the account balance."""
+
+        value = to_decimal(cost)
+        require_positive(value)
+        self._ensure_sufficient_funds(value)
+        self._balance -= value
+        reward = Reward(name=name, cost=value, description=description)
+        self._rewards.append(reward)
+        summary = description or f"Reward redeemed: {name}"
+        self._log_transaction(value, TransactionType.REWARD, summary)
+        return reward
+
+    def add_goal(self, name: str, target_amount: AmountLike, description: str = "") -> Goal:
+        """Create a new savings goal for the account."""
+
+        if name in self._goals:
+            raise ValueError(f"A goal named '{name}' already exists.")
+        goal = Goal(name=name, target_amount=target_amount, description=description)
+        self._goals[name] = goal
+        return goal
+
+    def contribute_to_goal(
+        self,
+        name: str,
+        amount: AmountLike,
+        *,
+        description: str | None = None,
+    ) -> Goal:
+        """Contribute funds from the balance towards a savings goal."""
+
+        goal = self._goals.get(name)
+        if goal is None:
+            raise GoalNotFoundError(f"Goal '{name}' does not exist.")
+        value = to_decimal(amount)
+        require_positive(value)
+        self._ensure_sufficient_funds(value)
+        self._balance -= value
+        goal.contribute(value)
+        summary = description or f"Contribution to goal: {name}"
+        self._log_transaction(value, TransactionType.GOAL_CONTRIBUTION, summary)
+        return goal
+
+    def transfer_to(
+        self,
+        other: "Account",
+        amount: AmountLike,
+        description: str | None = None,
+    ) -> tuple[Transaction, Transaction]:
+        """Transfer money from this account to another."""
+
+        if self is other:
+            raise ValueError("Cannot transfer to the same account.")
+
+        value = to_decimal(amount)
+        require_positive(value)
+        self._ensure_sufficient_funds(value)
+
+        self._balance -= value
+        outgoing_summary = description or f"Transfer to {other.child_name}"
+        outgoing = self._log_transaction(value, TransactionType.TRANSFER_OUT, outgoing_summary)
+
+        other._balance += value
+        incoming_summary = description or f"Transfer from {self.child_name}"
+        incoming = other._log_transaction(value, TransactionType.TRANSFER_IN, incoming_summary)
+
+        return outgoing, incoming
+
+    def recent_transactions(self, count: int = 5) -> Tuple[Transaction, ...]:
+        """Return the most recent ``count`` transactions."""
+
+        if count < 0:
+            raise ValueError("count must not be negative")
+        if count == 0:
+            return tuple()
+        return tuple(self._transactions[-count:])
+
+    def generate_statement(self, *, max_transactions: int = 10) -> str:
+        """Create a human-readable summary of the account state."""
+
+        lines = [
+            f"Account holder: {self.child_name}",
+            f"Current balance: {format_currency(self._balance)}",
+            "",
+            "Recent transactions:",
+        ]
+        transactions = self.recent_transactions(min(max_transactions, len(self._transactions)))
+        if not transactions:
+            lines.append("  (no transactions yet)")
+        else:
+            for transaction in transactions:
+                lines.append(
+                    "  "
+                    f"[{transaction.timestamp:%Y-%m-%d}] "
+                    f"{transaction.type.value.replace('_', ' ').title()}: "
+                    f"{format_currency(transaction.amount)} "
+                    f"(balance {format_currency(transaction.balance_after)})"
+                )
+        if self._goals:
+            lines.append("")
+            lines.append("Savings goals:")
+            for goal in self._goals.values():
+                status = "complete" if goal.is_complete else f"{goal.progress()*Decimal(100):.1f}%"
+                lines.append(
+                    "  "
+                    f"{goal.name}: saved {format_currency(goal.saved_amount)} "
+                    f"of {format_currency(goal.target_amount)} ({status})"
+                )
+        if self._rewards:
+            lines.append("")
+            lines.append("Redeemed rewards:")
+            for reward in self._rewards[-max_transactions:]:
+                lines.append(
+                    "  "
+                    f"[{reward.redeemed_at:%Y-%m-%d}] {reward.name} "
+                    f"for {format_currency(reward.cost)}"
+                )
+        return "\n".join(lines)
+
+    def _log_transaction(
+        self, amount: Decimal, transaction_type: TransactionType, description: str
+    ) -> Transaction:
+        transaction = Transaction(
+            amount=amount,
+            type=transaction_type,
+            description=description,
+            balance_after=self._balance,
+        )
+        self._transactions.append(transaction)
+        return transaction
+
+    def _ensure_sufficient_funds(self, amount: Decimal) -> None:
+        if self._balance < amount:
+            raise InsufficientFundsError(
+                f"Account '{self.child_name}' has insufficient funds for {format_currency(amount)}."
+            )

--- a/src/kidbank/exceptions.py
+++ b/src/kidbank/exceptions.py
@@ -1,0 +1,23 @@
+"""Custom exception hierarchy for the KidBank package."""
+
+from __future__ import annotations
+
+
+class KidBankError(Exception):
+    """Base class for all KidBank specific errors."""
+
+
+class DuplicateAccountError(KidBankError):
+    """Raised when attempting to create an account that already exists."""
+
+
+class AccountNotFoundError(KidBankError):
+    """Raised when an account lookup fails."""
+
+
+class InsufficientFundsError(KidBankError):
+    """Raised when an account operation would result in a negative balance."""
+
+
+class GoalNotFoundError(KidBankError):
+    """Raised when a requested savings goal cannot be found."""

--- a/src/kidbank/models.py
+++ b/src/kidbank/models.py
@@ -1,0 +1,98 @@
+"""Domain models used by the KidBank package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal, ROUND_HALF_UP
+from enum import Enum
+from .money import require_positive, to_decimal
+
+
+class TransactionType(str, Enum):
+    """Enumerates the supported types of account transactions."""
+
+    DEPOSIT = "deposit"
+    WITHDRAWAL = "withdrawal"
+    REWARD = "reward"
+    TRANSFER_IN = "transfer_in"
+    TRANSFER_OUT = "transfer_out"
+    GOAL_CONTRIBUTION = "goal_contribution"
+
+
+@dataclass(slots=True)
+class Transaction:
+    """Represents a single ledger entry for an :class:`~kidbank.account.Account`."""
+
+    amount: Decimal
+    type: TransactionType
+    description: str
+    balance_after: Decimal
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "amount", to_decimal(self.amount))
+        object.__setattr__(self, "balance_after", to_decimal(self.balance_after))
+
+
+@dataclass(slots=True)
+class Goal:
+    """Represents a savings goal that children can contribute towards."""
+
+    name: str
+    target_amount: Decimal
+    description: str = ""
+    saved_amount: Decimal = Decimal("0.00")
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    def __post_init__(self) -> None:
+        target = to_decimal(self.target_amount)
+        saved = to_decimal(self.saved_amount)
+        require_positive(target)
+        if saved < Decimal("0"):
+            raise ValueError("saved_amount cannot be negative.")
+        object.__setattr__(self, "target_amount", target)
+        object.__setattr__(self, "saved_amount", saved)
+
+    def contribute(self, amount: Decimal) -> Decimal:
+        """Increase the amount saved towards the goal."""
+
+        increment = to_decimal(amount)
+        require_positive(increment)
+        new_total = self.saved_amount + increment
+        object.__setattr__(self, "saved_amount", new_total)
+        return increment
+
+    @property
+    def remaining(self) -> Decimal:
+        """Return the amount still required to achieve the goal."""
+
+        remainder = self.target_amount - self.saved_amount
+        return remainder if remainder > Decimal("0") else Decimal("0.00")
+
+    @property
+    def is_complete(self) -> bool:
+        """True when the goal has been fully funded."""
+
+        return self.saved_amount >= self.target_amount
+
+    def progress(self) -> Decimal:
+        """Return the progress towards the goal as a decimal ratio (0-1)."""
+
+        ratio = self.saved_amount / self.target_amount
+        return ratio.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
+
+
+@dataclass(slots=True)
+class Reward:
+    """Represents a redeemed reward item."""
+
+    name: str
+    cost: Decimal
+    description: str = ""
+    redeemed_at: datetime = field(default_factory=datetime.utcnow)
+
+    def __post_init__(self) -> None:
+        cost = to_decimal(self.cost)
+        require_positive(cost)
+        object.__setattr__(self, "cost", cost)

--- a/src/kidbank/money.py
+++ b/src/kidbank/money.py
@@ -1,0 +1,43 @@
+"""Utilities for working with monetary values in KidBank."""
+
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Union
+
+CENT = Decimal("0.01")
+
+AmountLike = Union[Decimal, int, float, str]
+
+
+def to_decimal(value: AmountLike) -> Decimal:
+    """Convert ``value`` to a :class:`~decimal.Decimal` with two decimal places."""
+
+    if isinstance(value, Decimal):
+        result = value
+    elif isinstance(value, (int, float)):
+        result = Decimal(str(value))
+    elif isinstance(value, str):
+        result = Decimal(value)
+    else:  # pragma: no cover - defensive programming branch
+        raise TypeError(f"Unsupported amount type: {type(value)!r}")
+
+    return result.quantize(CENT, rounding=ROUND_HALF_UP)
+
+
+def require_positive(amount: Decimal, *, allow_zero: bool = False) -> Decimal:
+    """Ensure ``amount`` is positive (or non-negative when ``allow_zero`` is true)."""
+
+    if allow_zero:
+        if amount < Decimal("0"):
+            raise ValueError("Amount must be zero or greater.")
+    else:
+        if amount <= Decimal("0"):
+            raise ValueError("Amount must be greater than zero.")
+    return amount
+
+
+def format_currency(amount: Decimal) -> str:
+    """Return ``amount`` as a currency formatted string (e.g. ``$12.34``)."""
+
+    return f"${amount.quantize(CENT, rounding=ROUND_HALF_UP):,.2f}"

--- a/src/kidbank/service.py
+++ b/src/kidbank/service.py
@@ -1,0 +1,123 @@
+"""High level service for coordinating multiple KidBank accounts."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict, Tuple
+
+from .account import Account
+from .exceptions import AccountNotFoundError, DuplicateAccountError
+from .money import AmountLike, format_currency
+from .models import Goal, Reward, Transaction
+
+
+class KidBank:
+    """Manage multiple :class:`~kidbank.account.Account` instances."""
+
+    __slots__ = ("_accounts",)
+
+    def __init__(self) -> None:
+        self._accounts: Dict[str, Account] = {}
+
+    def create_account(self, child_name: str, *, starting_balance: AmountLike = 0) -> Account:
+        """Create and register a new account."""
+
+        if child_name in self._accounts:
+            raise DuplicateAccountError(f"Account '{child_name}' already exists.")
+        account = Account(child_name, starting_balance=starting_balance)
+        self._accounts[child_name] = account
+        return account
+
+    def list_accounts(self) -> Tuple[str, ...]:
+        """Return the names of all registered accounts."""
+
+        return tuple(sorted(self._accounts))
+
+    def has_account(self, child_name: str) -> bool:
+        """Return ``True`` if an account exists for ``child_name``."""
+
+        return child_name in self._accounts
+
+    def get_account(self, child_name: str) -> Account:
+        """Return the account for ``child_name`` or raise ``AccountNotFoundError``."""
+
+        try:
+            return self._accounts[child_name]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise AccountNotFoundError(f"Account '{child_name}' does not exist.") from exc
+
+    def deposit(self, child_name: str, amount: AmountLike, description: str = "Deposit") -> Transaction:
+        """Record a deposit for the specified account."""
+
+        return self.get_account(child_name).deposit(amount, description)
+
+    def withdraw(self, child_name: str, amount: AmountLike, description: str = "Withdrawal") -> Transaction:
+        """Record a withdrawal for the specified account."""
+
+        return self.get_account(child_name).withdraw(amount, description)
+
+    def transfer(
+        self,
+        sender: str,
+        recipient: str,
+        amount: AmountLike,
+        description: str | None = None,
+    ) -> tuple[Transaction, Transaction]:
+        """Transfer funds between two accounts."""
+
+        source = self.get_account(sender)
+        destination = self.get_account(recipient)
+        return source.transfer_to(destination, amount, description)
+
+    def redeem_reward(
+        self,
+        child_name: str,
+        *,
+        name: str,
+        cost: AmountLike,
+        description: str = "",
+    ) -> Reward:
+        """Redeem a reward for the specified account."""
+
+        return self.get_account(child_name).redeem_reward(name, cost, description)
+
+    def add_goal(
+        self,
+        child_name: str,
+        *,
+        name: str,
+        target_amount: AmountLike,
+        description: str = "",
+    ) -> Goal:
+        """Add a new goal to an account."""
+
+        return self.get_account(child_name).add_goal(name, target_amount, description)
+
+    def contribute_to_goal(
+        self,
+        child_name: str,
+        *,
+        name: str,
+        amount: AmountLike,
+        description: str | None = None,
+    ) -> Goal:
+        """Contribute funds to a specific goal for ``child_name``."""
+
+        return self.get_account(child_name).contribute_to_goal(name, amount, description=description)
+
+    def total_balance(self) -> Decimal:
+        """Return the aggregate balance across all accounts."""
+
+        return sum((account.balance for account in self._accounts.values()), Decimal("0.00"))
+
+    def summary(self) -> str:
+        """Return a multi-line report of all accounts and balances."""
+
+        if not self._accounts:
+            return "No accounts have been created yet."
+        lines = ["KidBank summary:"]
+        for name in sorted(self._accounts):
+            account = self._accounts[name]
+            lines.append(f"- {account.child_name}: {format_currency(account.balance)}")
+        lines.append(f"Total balance: {format_currency(self.total_balance())}")
+        return "\n".join(lines)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,88 @@
+from decimal import Decimal
+
+import pytest
+
+from kidbank.account import Account
+from kidbank.exceptions import GoalNotFoundError, InsufficientFundsError
+from kidbank.models import TransactionType
+
+
+def test_deposit_records_transaction() -> None:
+    account = Account("Ava")
+
+    transaction = account.deposit(10, "Weekly allowance")
+
+    assert account.balance == Decimal("10.00")
+    assert transaction.description == "Weekly allowance"
+    assert transaction.type is TransactionType.DEPOSIT
+    assert account.transactions[-1] is transaction
+
+
+def test_withdraw_reduces_balance() -> None:
+    account = Account("Ava")
+    account.deposit(Decimal("20"))
+
+    transaction = account.withdraw("5.50", "Book purchase")
+
+    assert account.balance == Decimal("14.50")
+    assert transaction.amount == Decimal("5.50")
+    assert transaction.type is TransactionType.WITHDRAWAL
+
+
+def test_withdraw_raises_when_insufficient_funds() -> None:
+    account = Account("Ava")
+
+    with pytest.raises(InsufficientFundsError):
+        account.withdraw(1)
+
+
+def test_reward_redemption_tracks_balance_and_history() -> None:
+    account = Account("Ava")
+    account.deposit(20)
+
+    reward = account.redeem_reward("Ice cream", 3, description="Dessert treat")
+
+    assert reward.cost == Decimal("3.00")
+    assert account.balance == Decimal("17.00")
+    last_transaction = account.transactions[-1]
+    assert last_transaction.type is TransactionType.REWARD
+    assert "Dessert" in last_transaction.description
+
+
+def test_goal_contribution_updates_goal_and_balance() -> None:
+    account = Account("Ava")
+    account.deposit(30)
+    goal = account.add_goal("Lego set", 50, description="Birthday gift")
+
+    updated_goal = account.contribute_to_goal("Lego set", 12.75)
+
+    assert updated_goal is goal
+    assert goal.saved_amount == Decimal("12.75")
+    assert account.balance == Decimal("17.25")
+
+    with pytest.raises(GoalNotFoundError):
+        account.contribute_to_goal("Non-existent", 5)
+
+    with pytest.raises(ValueError):
+        account.add_goal("Lego set", 10)
+
+
+def test_transfer_moves_funds_between_accounts() -> None:
+    giver = Account("Ava", starting_balance=25)
+    receiver = Account("Ben")
+
+    giver.deposit(5)  # starting balance logged as deposit; add an explicit deposit for clarity
+
+    outgoing, incoming = giver.transfer_to(receiver, 10, description="Sibling share")
+
+    assert giver.balance == Decimal("20.00")
+    assert receiver.balance == Decimal("10.00")
+    assert outgoing.type is TransactionType.TRANSFER_OUT
+    assert incoming.type is TransactionType.TRANSFER_IN
+    assert receiver.transactions[-1] is incoming
+
+    with pytest.raises(ValueError):
+        giver.transfer_to(giver, 1)
+
+    with pytest.raises(InsufficientFundsError):
+        giver.transfer_to(receiver, 100)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,81 @@
+from decimal import Decimal
+
+import pytest
+
+from kidbank.exceptions import AccountNotFoundError, DuplicateAccountError, InsufficientFundsError
+from kidbank.models import TransactionType
+from kidbank.service import KidBank
+
+
+def test_create_and_lookup_accounts() -> None:
+    bank = KidBank()
+
+    ava = bank.create_account("Ava", starting_balance=5)
+    assert bank.has_account("Ava")
+    assert ava.balance == Decimal("5.00")
+
+    with pytest.raises(DuplicateAccountError):
+        bank.create_account("Ava")
+
+    with pytest.raises(AccountNotFoundError):
+        bank.get_account("Nonexistent")
+
+
+def test_deposit_and_withdraw_workflow() -> None:
+    bank = KidBank()
+    bank.create_account("Ava")
+
+    deposit_tx = bank.deposit("Ava", 12.5, description="Chores")
+    assert deposit_tx.amount == Decimal("12.50")
+
+    withdrawal_tx = bank.withdraw("Ava", 2, description="Snack")
+    assert withdrawal_tx.amount == Decimal("2.00")
+    assert withdrawal_tx.type is TransactionType.WITHDRAWAL
+    assert bank.get_account("Ava").balance == Decimal("10.50")
+
+
+def test_transfer_between_accounts() -> None:
+    bank = KidBank()
+    bank.create_account("Ava")
+    bank.create_account("Ben")
+    bank.deposit("Ava", 15)
+
+    outgoing, incoming = bank.transfer("Ava", "Ben", 4.5, description="Gift")
+
+    assert outgoing.type is TransactionType.TRANSFER_OUT
+    assert incoming.type is TransactionType.TRANSFER_IN
+    assert bank.get_account("Ava").balance == Decimal("10.50")
+    assert bank.get_account("Ben").balance == Decimal("4.50")
+
+    with pytest.raises(InsufficientFundsError):
+        bank.transfer("Ava", "Ben", 100)
+
+
+def test_goals_and_rewards_via_service() -> None:
+    bank = KidBank()
+    bank.create_account("Ava")
+    bank.deposit("Ava", 30)
+
+    goal = bank.add_goal("Ava", name="Bicycle", target_amount=60)
+    assert goal.remaining == Decimal("60.00")
+
+    bank.contribute_to_goal("Ava", name="Bicycle", amount=20)
+    assert goal.saved_amount == Decimal("20.00")
+    assert goal.remaining == Decimal("40.00")
+
+    reward = bank.redeem_reward("Ava", name="Movie night", cost=5)
+    assert reward.name == "Movie night"
+    assert bank.get_account("Ava").balance == Decimal("5.00")
+
+
+def test_summary_lists_accounts() -> None:
+    bank = KidBank()
+    bank.create_account("Ava", starting_balance=2)
+    bank.create_account("Ben")
+    bank.deposit("Ben", 3)
+
+    summary = bank.summary()
+
+    assert "KidBank summary:" in summary
+    assert "Ava" in summary and "Ben" in summary
+    assert "Total balance" in summary


### PR DESCRIPTION
## Summary
- implement a well-organized KidBank Python package with account logic, domain models, money utilities, and service facade
- add unit tests covering account operations, goal contributions, rewards, and multi-account workflows
- document the package layout, usage example, and test instructions in the README

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d188cc1728832eaa4e48791ea26098