### PR TITLE
Expand KidBank platform capabilities

### DIFF
--- a/src/kidbank/__init__.py
+++ b/src/kidbank/__init__.py
@@ -1,6 +1,10 @@
 """KidBank package for managing reward-based banking for children."""
 
 from .account import Account
+from .admin import AuditLog, FeatureFlagRegistry, UndoManager
+from .api import ApiExporter, WebhookDispatcher
+from .chores import Chore, ChoreBoard, ChorePack, ChoreSchedule, TimeWindow, Weekday
+from .emailing import EmailClient
 from .exceptions import (
     AccountNotFoundError,
     DuplicateAccountError,
@@ -8,13 +12,54 @@ from .exceptions import (
     InsufficientFundsError,
     KidBankError,
 )
-from .models import Goal, Reward, Transaction, TransactionType
+from .i18n import Translator
+from .investing import InvestmentPortfolio
+from .models import (
+    BackupMetadata,
+    EventCategory,
+    FeatureFlag,
+    Goal,
+    KidSummary,
+    LeaderboardEntry,
+    NFCEvent,
+    PayoutRequest,
+    PayoutStatus,
+    Reward,
+    ScheduledDigest,
+    Transaction,
+    TransactionType,
+)
+from .notifications import Notification, NotificationCenter, NotificationChannel, NotificationType
+from .ops import BackupManager, HealthMonitor, StructuredLogger
+from .security import AuthManager
 from .service import KidBank
 
 __all__ = [
     "Account",
+    "AuditLog",
+    "AuthManager",
+    "ApiExporter",
+    "BackupManager",
+    "BackupMetadata",
+    "Chore",
+    "ChoreBoard",
+    "ChorePack",
+    "ChoreSchedule",
+    "EmailClient",
+    "EventCategory",
+    "FeatureFlag",
+    "FeatureFlagRegistry",
     "KidBank",
+    "KidSummary",
     "Goal",
+    "LeaderboardEntry",
+    "NFCEvent",
+    "Notification",
+    "NotificationCenter",
+    "NotificationChannel",
+    "NotificationType",
+    "InvestmentPortfolio",
+    "ScheduledDigest",
     "Reward",
     "Transaction",
     "TransactionType",
@@ -23,4 +68,13 @@ __all__ = [
     "DuplicateAccountError",
     "GoalNotFoundError",
     "InsufficientFundsError",
+    "PayoutRequest",
+    "PayoutStatus",
+    "StructuredLogger",
+    "HealthMonitor",
+    "TimeWindow",
+    "Translator",
+    "UndoManager",
+    "Weekday",
+    "WebhookDispatcher",
 ]

--- a/src/kidbank/admin.py
+++ b/src/kidbank/admin.py
@@ -1,0 +1,111 @@
+"""Administrative helpers for KidBank."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Callable, Dict, Optional
+from uuid import uuid4
+
+from .models import AuditEvent, FeatureFlag
+
+
+class AuditLog:
+    """Collect audit events for admin actions."""
+
+    def __init__(self) -> None:
+        self._entries: list[AuditEvent] = []
+
+    def record(
+        self,
+        actor: str,
+        action: str,
+        target: str,
+        *,
+        details: Optional[dict] = None,
+        timestamp: Optional[datetime] = None,
+    ) -> AuditEvent:
+        event = AuditEvent(
+            actor=actor,
+            action=action,
+            target=target,
+            timestamp=timestamp or datetime.utcnow(),
+            details=dict(details or {}),
+        )
+        self._entries.append(event)
+        return event
+
+    def entries(self, *, action: str | None = None, target: str | None = None) -> tuple[AuditEvent, ...]:
+        records = self._entries
+        if action is not None:
+            records = [entry for entry in records if entry.action == action]
+        if target is not None:
+            records = [entry for entry in records if entry.target == target]
+        return tuple(records)
+
+    def latest(self) -> AuditEvent | None:
+        return self._entries[-1] if self._entries else None
+
+
+class UndoManager:
+    """Utility that supports undoing the most recent action within a window."""
+
+    def __init__(self, *, window_seconds: int = 300) -> None:
+        self._window = timedelta(seconds=window_seconds)
+        self._last_event: tuple[str, datetime, Callable[[], None]] | None = None
+
+    def register(self, undo_callable: Callable[[], None], *, timestamp: Optional[datetime] = None) -> str:
+        event_id = str(uuid4())
+        self._last_event = (event_id, timestamp or datetime.utcnow(), undo_callable)
+        return event_id
+
+    def undo(self, *, at: Optional[datetime] = None) -> str:
+        if not self._last_event:
+            raise LookupError("No undoable action is available.")
+        event_id, event_time, undo_callable = self._last_event
+        moment = at or datetime.utcnow()
+        if moment - event_time > self._window:
+            raise TimeoutError("Undo window has expired.")
+        undo_callable()
+        self._last_event = None
+        return event_id
+
+
+class FeatureFlagRegistry:
+    """Minimal in-memory feature flag store backed by :class:`FeatureFlag`."""
+
+    def __init__(self, initial: Optional[Dict[str, bool]] = None) -> None:
+        self._flags: Dict[str, FeatureFlag] = {}
+        for key, enabled in (initial or {}).items():
+            self._flags[key] = FeatureFlag(key=key, enabled=bool(enabled))
+
+    def set(self, key: str, enabled: bool, *, description: str = "") -> FeatureFlag:
+        flag = FeatureFlag(key=key, enabled=enabled, description=description)
+        self._flags[key] = flag
+        return flag
+
+    def enable(self, key: str) -> FeatureFlag:
+        return self.set(key, True, description=self._flags.get(key, FeatureFlag(key, True)).description)
+
+    def disable(self, key: str) -> FeatureFlag:
+        return self.set(key, False, description=self._flags.get(key, FeatureFlag(key, False)).description)
+
+    def is_enabled(self, key: str, *, default: bool = False) -> bool:
+        flag = self._flags.get(key)
+        if flag is None:
+            return default
+        return flag.enabled
+
+    def describe(self, key: str, description: str) -> FeatureFlag:
+        flag = self._flags.get(key)
+        if not flag:
+            flag = FeatureFlag(key=key, enabled=False, description=description)
+        else:
+            flag = FeatureFlag(key=flag.key, enabled=flag.enabled, description=description)
+        self._flags[key] = flag
+        return flag
+
+    def list_flags(self) -> tuple[FeatureFlag, ...]:
+        return tuple(sorted(self._flags.values(), key=lambda flag: flag.key))
+
+
+__all__ = ["AuditLog", "FeatureFlagRegistry", "UndoManager"]

--- a/src/kidbank/api.py
+++ b/src/kidbank/api.py
@@ -1,0 +1,76 @@
+"""API helpers and webhook integrations for KidBank."""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Dict, TYPE_CHECKING
+
+from .models import Transaction
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .account import Account
+
+
+class ApiExporter:
+    """Convert KidBank data structures to JSON friendly dictionaries."""
+
+    def account_snapshot(self, account: "Account") -> Dict[str, object]:
+        return {
+            "child": account.child_name,
+            "balance": float(account.balance),
+            "escrow_balance": float(account.escrow_balance),
+            "transactions": [self._serialise_transaction(tx) for tx in account.transactions],
+            "goals": [
+                {
+                    "name": goal.name,
+                    "target": float(goal.target_amount),
+                    "saved": float(goal.saved_amount),
+                    "progress": float(goal.progress()),
+                    "image": goal.image_url,
+                }
+                for goal in account.goals
+            ],
+            "rewards": [
+                {
+                    "name": reward.name,
+                    "cost": float(reward.cost),
+                    "redeemed_at": reward.redeemed_at.isoformat(),
+                }
+                for reward in account.rewards
+            ],
+        }
+
+    def to_json(self, payload: Dict[str, object]) -> str:
+        return json.dumps(payload, sort_keys=True)
+
+    def _serialise_transaction(self, transaction: Transaction) -> Dict[str, object]:
+        return {
+            "timestamp": transaction.timestamp.isoformat(),
+            "type": transaction.type.value,
+            "category": transaction.category.value if transaction.category else None,
+            "amount": float(transaction.amount),
+            "description": transaction.description,
+        }
+
+
+class WebhookDispatcher:
+    """Simple synchronous webhook broadcaster."""
+
+    def __init__(self) -> None:
+        self._listeners: list[Callable[[Dict[str, object]], None]] = []
+
+    def register(self, listener: Callable[[Dict[str, object]], None]) -> None:
+        self._listeners.append(listener)
+
+    def unregister(self, listener: Callable[[Dict[str, object]], None]) -> None:
+        try:
+            self._listeners.remove(listener)
+        except ValueError:
+            pass
+
+    def dispatch(self, event: Dict[str, object]) -> None:
+        for listener in list(self._listeners):
+            listener(event)
+
+
+__all__ = ["ApiExporter", "WebhookDispatcher"]

--- a/src/kidbank/emailing.py
+++ b/src/kidbank/emailing.py
@@ -1,0 +1,59 @@
+"""Simple SMTP email helper for KidBank notifications."""
+
+from __future__ import annotations
+
+from email.message import EmailMessage
+from typing import List, Optional, Sequence
+
+
+class EmailClient:
+    """Very small wrapper around :mod:`smtplib` with test-friendly fallbacks."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        *,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        use_tls: bool = True,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.use_tls = use_tls
+        self._outbox: List[EmailMessage] = []
+
+    def build_message(self, subject: str, body: str, *, sender: str, recipients: Sequence[str]) -> EmailMessage:
+        message = EmailMessage()
+        message["Subject"] = subject
+        message["From"] = sender
+        message["To"] = ", ".join(recipients)
+        message.set_content(body)
+        return message
+
+    def send(self, message: EmailMessage) -> None:
+        try:
+            import smtplib
+
+            if self.use_tls:
+                with smtplib.SMTP(self.host, self.port, timeout=5) as smtp:
+                    smtp.starttls()
+                    if self.username and self.password:
+                        smtp.login(self.username, self.password)
+                    smtp.send_message(message)
+            else:
+                with smtplib.SMTP(self.host, self.port, timeout=5) as smtp:
+                    if self.username and self.password:
+                        smtp.login(self.username, self.password)
+                    smtp.send_message(message)
+        except Exception:  # pragma: no cover - network operations optional
+            # Store messages locally for inspection when SMTP is unavailable.
+            self._outbox.append(message)
+
+    def deliveries(self) -> Sequence[EmailMessage]:
+        return tuple(self._outbox)
+
+
+__all__ = ["EmailClient"]

--- a/src/kidbank/i18n.py
+++ b/src/kidbank/i18n.py
@@ -1,0 +1,41 @@
+"""Internationalisation helpers for KidBank."""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping, Optional
+
+
+class Translator:
+    """Store translations for short interface strings."""
+
+    def __init__(self, default_locale: str = "en", *, translations: Optional[Mapping[str, Mapping[str, str]]] = None) -> None:
+        self.default_locale = default_locale
+        self._translations: Dict[str, Dict[str, str]] = {
+            "en": {
+                "dashboard.title": "KidBank Dashboard",
+                "dashboard.pending": "Pending chores",
+                "dashboard.next_allowance": "Next allowance",
+            },
+            "es": {
+                "dashboard.title": "Panel KidBank",
+                "dashboard.pending": "Tareas pendientes",
+                "dashboard.next_allowance": "Próxima mesada",
+            },
+        }
+        if translations:
+            for locale, mapping in translations.items():
+                self._translations.setdefault(locale, {}).update(mapping)
+
+    def set_translation(self, locale: str, key: str, value: str) -> None:
+        self._translations.setdefault(locale, {})[key] = value
+
+    def translate(self, key: str, *, locale: Optional[str] = None) -> str:
+        target_locale = locale or self.default_locale
+        language = self._translations.get(target_locale) or self._translations[self.default_locale]
+        return language.get(key, key)
+
+    def available_locales(self) -> tuple[str, ...]:
+        return tuple(sorted(self._translations))
+
+
+__all__ = ["Translator"]

--- a/src/kidbank/investing.py
+++ b/src/kidbank/investing.py
@@ -1,0 +1,133 @@
+"""Investing helpers for KidBank."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal, ROUND_UP
+from typing import Dict, Optional
+
+
+@dataclass(slots=True)
+class DCAConfig:
+    amount: Decimal
+    interval: timedelta
+    next_run: datetime
+    active: bool = True
+
+    def schedule_next(self) -> None:
+        self.next_run += self.interval
+
+
+class InvestmentPortfolio:
+    """Track cash and simulated stock/bond balances for a child."""
+
+    def __init__(self) -> None:
+        self.positions: Dict[str, Decimal] = {
+            "cash": Decimal("0.00"),
+            "stock": Decimal("0.00"),
+            "bond": Decimal("0.00"),
+        }
+        self.auto_sweep_enabled = True
+        self.allocation: Dict[str, Decimal] = {"stock": Decimal("0.70"), "bond": Decimal("0.30")}
+        self.dca: Optional[DCAConfig] = None
+        self.explainers: Dict[str, str] = {
+            "risk": "Investing involves ups and downs. Holding both stocks and bonds spreads the risk.",
+            "p_l": "Profit and loss shows how much your investments changed from what you put in.",
+            "diversification": "Putting money in different buckets keeps your eggs out of one basket.",
+        }
+
+    # Cash handling ---------------------------------------------------------
+    def record_deposit(self, amount: Decimal) -> Decimal:
+        amount = Decimal(amount).quantize(Decimal("0.01"))
+        self.positions["cash"] += amount
+        if self.auto_sweep_enabled:
+            swept = self.auto_cash_sweep(amount)
+        else:
+            swept = Decimal("0.00")
+        return swept
+
+    def auto_cash_sweep(self, deposit_amount: Decimal) -> Decimal:
+        value = Decimal(deposit_amount).quantize(Decimal("0.01"))
+        ceiling = value.quantize(Decimal("1"), rounding=ROUND_UP)
+        spare = (ceiling - value).quantize(Decimal("0.01"))
+        if spare <= Decimal("0.00"):
+            return Decimal("0.00")
+        if self.positions["cash"] < spare:
+            return Decimal("0.00")
+        self.positions["cash"] -= spare
+        self._invest(spare)
+        return spare
+
+    def _invest(self, amount: Decimal) -> None:
+        total_weight = sum(self.allocation.values())
+        if total_weight == 0:
+            self.positions["stock"] += amount
+            return
+        allocated = Decimal("0.00")
+        for asset, weight in self.allocation.items():
+            portion = (amount * (weight / total_weight)).quantize(Decimal("0.01"))
+            self.positions.setdefault(asset, Decimal("0.00"))
+            self.positions[asset] += portion
+            allocated += portion
+        residual = amount - allocated
+        if residual != Decimal("0.00"):
+            self.positions["cash"] += residual
+
+    # DCA -------------------------------------------------------------------
+    def configure_dca(
+        self,
+        amount: Decimal,
+        *,
+        start: Optional[datetime] = None,
+        interval_days: int = 7,
+    ) -> DCAConfig:
+        config = DCAConfig(
+            amount=Decimal(amount).quantize(Decimal("0.01")),
+            interval=timedelta(days=interval_days),
+            next_run=start or datetime.utcnow(),
+        )
+        self.dca = config
+        return config
+
+    def toggle_dca(self, active: bool) -> None:
+        if not self.dca:
+            raise RuntimeError("No DCA configuration set.")
+        self.dca.active = active
+
+    def run_dca_if_due(self, *, at: Optional[datetime] = None) -> Decimal:
+        if not self.dca or not self.dca.active:
+            return Decimal("0.00")
+        moment = at or datetime.utcnow()
+        if moment < self.dca.next_run:
+            return Decimal("0.00")
+        amount = self.dca.amount
+        if self.positions["cash"] < amount:
+            return Decimal("0.00")
+        self.positions["cash"] -= amount
+        self._invest(amount)
+        self.dca.schedule_next()
+        return amount
+
+    # Portfolio summaries ---------------------------------------------------
+    def total_value(self) -> Decimal:
+        return sum(self.positions.values())
+
+    def allocation_breakdown(self) -> Dict[str, float]:
+        total = float(self.total_value())
+        if total == 0:
+            return {asset: 0.0 for asset in self.positions}
+        return {asset: float(balance / total) for asset, balance in self.positions.items()}
+
+    def set_allocation(self, *, stock: float, bond: float) -> None:
+        total = stock + bond
+        if total <= 0:
+            raise ValueError("Allocation weights must be positive.")
+        self.allocation["stock"] = Decimal(stock / total).quantize(Decimal("0.01"))
+        self.allocation["bond"] = Decimal(bond / total).quantize(Decimal("0.01"))
+
+    def explain(self, topic: str) -> str:
+        return self.explainers.get(topic, "Ask a grown-up for details about this topic!")
+
+
+__all__ = ["DCAConfig", "InvestmentPortfolio"]

--- a/src/kidbank/notifications.py
+++ b/src/kidbank/notifications.py
@@ -1,0 +1,117 @@
+"""Notification primitives for KidBank."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Dict, List, Sequence
+
+from .models import ScheduledDigest
+
+
+class NotificationChannel(str, Enum):
+    EMAIL = "email"
+    SMS = "sms"
+    PUSH = "push"
+
+
+class NotificationType(str, Enum):
+    CHORE_REMINDER = "chore_reminder"
+    PAYOUT_POSTED = "payout_posted"
+    WEEKLY_DIGEST = "weekly_digest"
+    GOAL_MILESTONE = "goal_milestone"
+    OTHER = "other"
+
+
+@dataclass(slots=True)
+class Notification:
+    """Simple representation of a notification waiting to be delivered."""
+
+    recipient: str
+    channel: NotificationChannel
+    type: NotificationType
+    subject: str
+    body: str
+    metadata: Dict[str, str] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    def as_dict(self) -> Dict[str, str]:
+        payload = {
+            "recipient": self.recipient,
+            "channel": self.channel.value,
+            "type": self.type.value,
+            "subject": self.subject,
+            "body": self.body,
+            "created_at": self.created_at.isoformat(),
+        }
+        payload.update(self.metadata)
+        return payload
+
+
+class NotificationCenter:
+    """In-memory notification inbox used for tests and integrations."""
+
+    def __init__(self) -> None:
+        self._queue: List[Notification] = []
+        self._sent: List[Notification] = []
+        self._scheduled: List[ScheduledDigest] = []
+
+    def queue(self, notification: Notification) -> None:
+        self._queue.append(notification)
+
+    def pending(self, *, notification_type: NotificationType | None = None) -> Sequence[Notification]:
+        if notification_type is None:
+            return tuple(self._queue)
+        return tuple(item for item in self._queue if item.type is notification_type)
+
+    def pop_all(self) -> Sequence[Notification]:
+        pending = tuple(self._queue)
+        self._queue.clear()
+        self._sent.extend(pending)
+        return pending
+
+    def mark_sent(self, notification: Notification) -> None:
+        self._sent.append(notification)
+        try:
+            self._queue.remove(notification)
+        except ValueError:
+            pass
+
+    def history(self) -> Sequence[Notification]:
+        return tuple(self._sent)
+
+    # Weekly digest helpers -------------------------------------------------
+    def schedule_digest(self, digest: ScheduledDigest) -> None:
+        self._scheduled.append(digest)
+
+    def due_digests(self, *, at: datetime | None = None) -> Sequence[ScheduledDigest]:
+        moment = at or datetime.utcnow()
+        ready = [digest for digest in self._scheduled if digest.send_on <= moment]
+        self._scheduled = [digest for digest in self._scheduled if digest.send_on > moment]
+        return tuple(ready)
+
+    def queue_digest_notifications(self, *, at: datetime | None = None) -> Sequence[Notification]:
+        notifications: List[Notification] = []
+        for digest in self.due_digests(at=at):
+            body_lines = ["Weekly digest summary:"]
+            for key, value in digest.summary.items():
+                body_lines.append(f"- {key}: {value}")
+            notification = Notification(
+                recipient=digest.recipient,
+                channel=NotificationChannel.EMAIL,
+                type=NotificationType.WEEKLY_DIGEST,
+                subject="KidBank weekly digest",
+                body="\n".join(body_lines),
+            )
+            self.queue(notification)
+            notifications.append(notification)
+        return tuple(notifications)
+
+
+__all__ = [
+    "Notification",
+    "NotificationCenter",
+    "NotificationChannel",
+    "NotificationType",
+]

--- a/src/kidbank/ops.py
+++ b/src/kidbank/ops.py
@@ -1,0 +1,100 @@
+"""Operational utilities for KidBank."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+from uuid import uuid4
+
+from .models import BackupMetadata
+
+
+class BackupManager:
+    """Manage rolling backups of the in-memory SQLite database."""
+
+    def __init__(self) -> None:
+        self._backups: Dict[str, tuple[BackupMetadata, bytes]] = {}
+
+    def create_backup(self, payload: bytes | str | dict, *, label: str = "") -> BackupMetadata:
+        data: bytes
+        if isinstance(payload, bytes):
+            data = payload
+        elif isinstance(payload, str):
+            data = payload.encode("utf-8")
+        else:
+            data = json.dumps(payload, sort_keys=True).encode("utf-8")
+        backup_id = str(uuid4())
+        metadata = BackupMetadata(
+            backup_id=backup_id,
+            created_at=datetime.utcnow(),
+            label=label or backup_id,
+            size_bytes=len(data),
+        )
+        self._backups[backup_id] = (metadata, data)
+        return metadata
+
+    def get_backup(self, backup_id: str) -> tuple[BackupMetadata, bytes]:
+        return self._backups[backup_id]
+
+    def list_backups(self) -> tuple[BackupMetadata, ...]:
+        return tuple(sorted((meta for meta, _ in self._backups.values()), key=lambda meta: meta.created_at))
+
+    def purge_old(self, retain: int = 7) -> None:
+        if retain <= 0:
+            self._backups.clear()
+            return
+        backups = sorted(self._backups.values(), key=lambda item: item[0].created_at, reverse=True)
+        for metadata, _ in backups[retain:]:
+            self._backups.pop(metadata.backup_id, None)
+
+
+class HealthMonitor:
+    """Aggregate runtime health information for status pages."""
+
+    def __init__(self) -> None:
+        self.database_online = True
+        self.migrations: list[str] = []
+        self.cache_timestamp: Optional[datetime] = None
+
+    def set_cache_timestamp(self, timestamp: datetime) -> None:
+        self.cache_timestamp = timestamp
+
+    def add_migration(self, name: str) -> None:
+        self.migrations.append(name)
+
+    def status(self) -> dict:
+        return {
+            "database": "ok" if self.database_online else "down",
+            "migrations": list(self.migrations),
+            "sp500_cache_age_seconds": self.cache_age_seconds(),
+        }
+
+    def cache_age_seconds(self) -> Optional[int]:
+        if not self.cache_timestamp:
+            return None
+        return int((datetime.utcnow() - self.cache_timestamp).total_seconds())
+
+
+class StructuredLogger:
+    """Write JSON lines log entries for admin inspection."""
+
+    def __init__(self, *, path: Path | None = None) -> None:
+        self.path = path
+        self._entries: list[dict] = []
+
+    def log(self, event_type: str, **fields: object) -> dict:
+        entry = {"timestamp": datetime.utcnow().isoformat(), "event": event_type, **fields}
+        self._entries.append(entry)
+        if self.path:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(entry) + "\n")
+        return entry
+
+    def tail(self, limit: int = 50) -> tuple[dict, ...]:
+        return tuple(self._entries[-limit:])
+
+
+__all__ = ["BackupManager", "HealthMonitor", "StructuredLogger"]

--- a/src/kidbank/security.py
+++ b/src/kidbank/security.py
@@ -1,0 +1,155 @@
+"""Security helpers used by the expanded KidBank feature set."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from secrets import token_urlsafe
+from typing import Deque, Dict, Iterable, Optional
+from uuid import uuid4
+
+
+@dataclass(slots=True)
+class Session:
+    """Represents an authenticated session with CSRF metadata."""
+
+    id: str
+    user_id: str
+    expires_at: datetime
+    remember_me: bool
+    csrf_token: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    def is_expired(self, *, at: Optional[datetime] = None) -> bool:
+        moment = at or datetime.utcnow()
+        return moment >= self.expires_at
+
+    def refresh_csrf(self) -> str:
+        self.csrf_token = token_urlsafe(16)
+        return self.csrf_token
+
+
+class AuthManager:
+    """Provide coarse security controls for the in-memory application."""
+
+    def __init__(
+        self,
+        *,
+        max_attempts: int = 5,
+        lockout_minutes: int = 15,
+        session_minutes: int = 60,
+        remember_days: int = 30,
+    ) -> None:
+        self._max_attempts = max_attempts
+        self._lockout_window = timedelta(minutes=lockout_minutes)
+        self._session_duration = timedelta(minutes=session_minutes)
+        self._remember_duration = timedelta(days=remember_days)
+        self._login_attempts: Dict[str, Deque[datetime]] = {}
+        self._pin_attempts: Dict[str, Deque[datetime]] = {}
+        self._sessions: Dict[str, Session] = {}
+
+    # ------------------------------------------------------------------
+    # Rate limiting helpers
+    # ------------------------------------------------------------------
+    def record_login_attempt(self, user_id: str, *, success: bool, at: Optional[datetime] = None) -> bool:
+        """Record a login attempt and return whether authentication should proceed."""
+
+        return self._record_attempt(self._login_attempts, user_id, success, at)
+
+    def record_pin_attempt(self, user_id: str, *, success: bool, at: Optional[datetime] = None) -> bool:
+        """Record a PIN verification attempt and return whether verification is allowed."""
+
+        return self._record_attempt(self._pin_attempts, user_id, success, at)
+
+    def is_locked(self, user_id: str, *, at: Optional[datetime] = None) -> bool:
+        """Return ``True`` when ``user_id`` is currently locked out."""
+
+        return self._has_exceeded(self._login_attempts, user_id, at) or self._has_exceeded(
+            self._pin_attempts, user_id, at
+        )
+
+    def _record_attempt(
+        self,
+        store: Dict[str, Deque[datetime]],
+        user_id: str,
+        success: bool,
+        at: Optional[datetime],
+    ) -> bool:
+        now = at or datetime.utcnow()
+        bucket = store.setdefault(user_id, deque())
+        self._prune(bucket, now)
+        if success:
+            bucket.clear()
+            return True
+        bucket.append(now)
+        return len(bucket) < self._max_attempts
+
+    def _has_exceeded(self, store: Dict[str, Deque[datetime]], user_id: str, at: Optional[datetime]) -> bool:
+        now = at or datetime.utcnow()
+        bucket = store.get(user_id)
+        if not bucket:
+            return False
+        self._prune(bucket, now)
+        return len(bucket) >= self._max_attempts
+
+    def _prune(self, bucket: Deque[datetime], now: datetime) -> None:
+        while bucket and now - bucket[0] > self._lockout_window:
+            bucket.popleft()
+
+    # ------------------------------------------------------------------
+    # Session handling helpers
+    # ------------------------------------------------------------------
+    def create_session(self, user_id: str, *, remember_me: bool = False, at: Optional[datetime] = None) -> Session:
+        """Create a new session while honouring lockout constraints."""
+
+        if self.is_locked(user_id, at=at):
+            raise PermissionError("User is locked out due to repeated failed attempts.")
+        now = at or datetime.utcnow()
+        expiry = now + (self._remember_duration if remember_me else self._session_duration)
+        session = Session(id=str(uuid4()), user_id=user_id, expires_at=expiry, remember_me=remember_me, csrf_token="")
+        session.refresh_csrf()
+        self._sessions[session.id] = session
+        return session
+
+    def validate_session(self, session_id: str, *, at: Optional[datetime] = None) -> bool:
+        session = self._sessions.get(session_id)
+        if not session:
+            return False
+        if session.is_expired(at=at):
+            self._sessions.pop(session_id, None)
+            return False
+        return True
+
+    def get_session(self, session_id: str) -> Optional[Session]:
+        return self._sessions.get(session_id)
+
+    def expire_sessions(self, *, at: Optional[datetime] = None) -> None:
+        now = at or datetime.utcnow()
+        expired = [session_id for session_id, session in self._sessions.items() if session.is_expired(at=now)]
+        for session_id in expired:
+            self._sessions.pop(session_id, None)
+
+    def logout(self, session_id: str) -> None:
+        self._sessions.pop(session_id, None)
+
+    def rotate_csrf(self, session_id: str) -> str:
+        session = self._sessions.get(session_id)
+        if not session:
+            raise KeyError(f"Unknown session id '{session_id}'.")
+        return session.refresh_csrf()
+
+    def validate_csrf(self, session_id: str, token: str) -> bool:
+        session = self._sessions.get(session_id)
+        if not session:
+            return False
+        if session.is_expired():
+            self._sessions.pop(session_id, None)
+            return False
+        return session.csrf_token == token
+
+    def active_sessions(self, user_id: str) -> Iterable[Session]:
+        return tuple(session for session in self._sessions.values() if session.user_id == user_id)
+
+
+__all__ = ["AuthManager", "Session"]

--- a/src/kidbank/service.py
+++ b/src/kidbank/service.py
@@ -2,59 +2,174 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
+from datetime import datetime
 from decimal import Decimal
-from typing import Dict, Tuple
+from typing import Callable, Dict, Mapping, Optional, Sequence, Tuple
+from uuid import uuid4
 
 from .account import Account
+from .admin import AuditLog, FeatureFlagRegistry, UndoManager
+from .api import ApiExporter, WebhookDispatcher
+from .chores import Chore, ChoreBoard, ChorePack, ChoreSchedule, TimeWindow, Weekday
 from .exceptions import AccountNotFoundError, DuplicateAccountError
-from .money import AmountLike, format_currency
-from .models import Goal, Reward, Transaction
+from .i18n import Translator
+from .investing import InvestmentPortfolio
+from .models import (
+    EventCategory,
+    Goal,
+    KidSummary,
+    LeaderboardEntry,
+    NFCEvent,
+    Reward,
+    PayoutRequest,
+    PayoutStatus,
+    ScheduledDigest,
+    Transaction,
+    TransactionType,
+    BackupMetadata,
+)
+from .money import AmountLike, format_currency, to_decimal
+from .notifications import Notification, NotificationCenter, NotificationChannel, NotificationType
+from .ops import BackupManager, HealthMonitor, StructuredLogger
+from .security import AuthManager
 
 
 class KidBank:
-    """Manage multiple :class:`~kidbank.account.Account` instances."""
+    """Manage accounts, chores, investing and administrative workflows."""
 
-    __slots__ = ("_accounts",)
+    __slots__ = (
+        "_accounts",
+        "_chores",
+        "_portfolios",
+        "_notifications",
+        "_audit_log",
+        "_undo",
+        "_feature_flags",
+        "_webhooks",
+        "_auth",
+        "_backups",
+        "_health",
+        "_logger",
+        "_pending_payouts",
+        "_soft_limits",
+        "_parent_contacts",
+        "_kid_contacts",
+        "_goal_milestones",
+        "_translator",
+        "_api",
+        "_nfc_events",
+        "_badge_thresholds",
+        "_earned_badges",
+        "_next_allowance_eta",
+        "_default_soft_limit",
+    )
 
-    def __init__(self) -> None:
+    def __init__(self, *, soft_limit: AmountLike = Decimal("20")) -> None:
         self._accounts: Dict[str, Account] = {}
+        self._chores: Dict[str, ChoreBoard] = {}
+        self._portfolios: Dict[str, InvestmentPortfolio] = {}
+        self._notifications = NotificationCenter()
+        self._audit_log = AuditLog()
+        self._undo = UndoManager()
+        self._feature_flags = FeatureFlagRegistry(
+            {
+                "investing": True,
+                "badges": True,
+                "sms": True,
+                "leaderboard": True,
+            }
+        )
+        self._webhooks = WebhookDispatcher()
+        self._auth = AuthManager()
+        self._backups = BackupManager()
+        self._health = HealthMonitor()
+        self._logger = StructuredLogger()
+        self._pending_payouts: Dict[str, PayoutRequest] = {}
+        self._soft_limits: Dict[str, Decimal] = {}
+        self._parent_contacts: Dict[str, Dict[str, str]] = defaultdict(dict)
+        self._kid_contacts: Dict[str, Dict[str, str]] = defaultdict(dict)
+        self._goal_milestones: Dict[tuple[str, str], set[int]] = defaultdict(set)
+        self._translator = Translator()
+        self._api = ApiExporter()
+        self._nfc_events: list[NFCEvent] = []
+        self._badge_thresholds: Dict[str, int] = {
+            "Rising Star": 5,
+            "Chore Champion": 25,
+            "Legend": 50,
+        }
+        self._earned_badges: Dict[str, set[str]] = defaultdict(set)
+        self._next_allowance_eta: Dict[str, Optional[datetime]] = {}
+        self._default_soft_limit = to_decimal(soft_limit)
 
+    # ------------------------------------------------------------------
+    # Core account operations
+    # ------------------------------------------------------------------
     def create_account(self, child_name: str, *, starting_balance: AmountLike = 0) -> Account:
-        """Create and register a new account."""
-
         if child_name in self._accounts:
             raise DuplicateAccountError(f"Account '{child_name}' already exists.")
         account = Account(child_name, starting_balance=starting_balance)
         self._accounts[child_name] = account
+        self._chores[child_name] = ChoreBoard()
+        self._portfolios[child_name] = InvestmentPortfolio()
+        self._soft_limits[child_name] = self._default_soft_limit
+        self._next_allowance_eta[child_name] = None
+        self._audit_log.record("system", "create_account", child_name)
+        self._logger.log("account_created", child=child_name, balance=float(account.balance))
+        self._webhooks.dispatch({"event": "account_created", "child": child_name})
         return account
 
     def list_accounts(self) -> Tuple[str, ...]:
-        """Return the names of all registered accounts."""
-
         return tuple(sorted(self._accounts))
 
     def has_account(self, child_name: str) -> bool:
-        """Return ``True`` if an account exists for ``child_name``."""
-
         return child_name in self._accounts
 
     def get_account(self, child_name: str) -> Account:
-        """Return the account for ``child_name`` or raise ``AccountNotFoundError``."""
-
         try:
             return self._accounts[child_name]
         except KeyError as exc:  # pragma: no cover - defensive guard
             raise AccountNotFoundError(f"Account '{child_name}' does not exist.") from exc
 
-    def deposit(self, child_name: str, amount: AmountLike, description: str = "Deposit") -> Transaction:
-        """Record a deposit for the specified account."""
+    def deposit(
+        self,
+        child_name: str,
+        amount: AmountLike,
+        description: str = "Deposit",
+        *,
+        category: EventCategory | None = None,
+        metadata: Optional[Mapping[str, str]] = None,
+    ) -> Transaction:
+        transaction = self.get_account(child_name).deposit(
+            amount,
+            description,
+            category=category,
+            metadata=metadata,
+        )
+        self._after_transaction(child_name, transaction)
+        swept = self._portfolios[child_name].record_deposit(transaction.amount)
+        if swept > Decimal("0"):
+            self._logger.log("auto_sweep", child=child_name, amount=float(swept))
+        self._notify_payout(child_name, transaction)
+        return transaction
 
-        return self.get_account(child_name).deposit(amount, description)
-
-    def withdraw(self, child_name: str, amount: AmountLike, description: str = "Withdrawal") -> Transaction:
-        """Record a withdrawal for the specified account."""
-
-        return self.get_account(child_name).withdraw(amount, description)
+    def withdraw(
+        self,
+        child_name: str,
+        amount: AmountLike,
+        description: str = "Withdrawal",
+        *,
+        category: EventCategory | None = None,
+        metadata: Optional[Mapping[str, str]] = None,
+    ) -> Transaction:
+        transaction = self.get_account(child_name).withdraw(
+            amount,
+            description,
+            category=category,
+            metadata=metadata,
+        )
+        self._after_transaction(child_name, transaction)
+        return transaction
 
     def transfer(
         self,
@@ -63,11 +178,12 @@ class KidBank:
         amount: AmountLike,
         description: str | None = None,
     ) -> tuple[Transaction, Transaction]:
-        """Transfer funds between two accounts."""
-
         source = self.get_account(sender)
         destination = self.get_account(recipient)
-        return source.transfer_to(destination, amount, description)
+        outgoing, incoming = source.transfer_to(destination, amount, description)
+        self._after_transaction(sender, outgoing)
+        self._after_transaction(recipient, incoming)
+        return outgoing, incoming
 
     def redeem_reward(
         self,
@@ -77,9 +193,10 @@ class KidBank:
         cost: AmountLike,
         description: str = "",
     ) -> Reward:
-        """Redeem a reward for the specified account."""
-
-        return self.get_account(child_name).redeem_reward(name, cost, description)
+        reward = self.get_account(child_name).redeem_reward(name, cost, description=description)
+        self._audit_log.record("guardian", "redeem_reward", f"{child_name}:{name}")
+        self._logger.log("reward_redeemed", child=child_name, reward=name, cost=float(reward.cost))
+        return reward
 
     def add_goal(
         self,
@@ -88,10 +205,17 @@ class KidBank:
         name: str,
         target_amount: AmountLike,
         description: str = "",
+        image_url: str = "",
     ) -> Goal:
-        """Add a new goal to an account."""
-
-        return self.get_account(child_name).add_goal(name, target_amount, description)
+        goal = self.get_account(child_name).add_goal(
+            name,
+            target_amount,
+            description=description,
+            image_url=image_url,
+        )
+        self._audit_log.record("guardian", "add_goal", f"{child_name}:{name}")
+        self._logger.log("goal_added", child=child_name, goal=name, target=float(goal.target_amount))
+        return goal
 
     def contribute_to_goal(
         self,
@@ -101,18 +225,16 @@ class KidBank:
         amount: AmountLike,
         description: str | None = None,
     ) -> Goal:
-        """Contribute funds to a specific goal for ``child_name``."""
-
-        return self.get_account(child_name).contribute_to_goal(name, amount, description=description)
+        goal = self.get_account(child_name).contribute_to_goal(name, amount, description=description)
+        self._audit_log.record("guardian", "contribute_goal", f"{child_name}:{name}")
+        self._logger.log("goal_contribution", child=child_name, goal=name, saved=float(goal.saved_amount))
+        self._check_goal_milestones(child_name, goal)
+        return goal
 
     def total_balance(self) -> Decimal:
-        """Return the aggregate balance across all accounts."""
-
         return sum((account.balance for account in self._accounts.values()), Decimal("0.00"))
 
     def summary(self) -> str:
-        """Return a multi-line report of all accounts and balances."""
-
         if not self._accounts:
             return "No accounts have been created yet."
         lines = ["KidBank summary:"]
@@ -121,3 +243,527 @@ class KidBank:
             lines.append(f"- {account.child_name}: {format_currency(account.balance)}")
         lines.append(f"Total balance: {format_currency(self.total_balance())}")
         return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Chore management and gamification
+    # ------------------------------------------------------------------
+    def schedule_chore(
+        self,
+        child_name: str,
+        *,
+        name: str,
+        value: AmountLike,
+        weekdays: Sequence[int | Weekday],
+        after: Optional[TimeWindow | Tuple[int, int]] = None,
+        before: Optional[Tuple[int, int]] = None,
+        requires_proof: bool = False,
+        proof_type: str | None = None,
+    ) -> Chore:
+        board = self._chores[child_name]
+        weekday_set = frozenset(Weekday(day) for day in weekdays)
+        window: TimeWindow | None
+        if isinstance(after, TimeWindow):
+            window = after
+        elif after or before:
+            start = None
+            end = None
+            if isinstance(after, tuple):
+                start = datetime.utcnow().replace(hour=after[0], minute=after[1], second=0, microsecond=0).time()
+            if isinstance(before, tuple):
+                end = datetime.utcnow().replace(hour=before[0], minute=before[1], second=0, microsecond=0).time()
+            window = TimeWindow(start=start, end=end)
+        else:
+            window = None
+        chore = Chore(
+            name=name,
+            value=to_decimal(value),
+            schedule=ChoreSchedule(weekdays=weekday_set, window=window),
+            requires_proof=requires_proof,
+            proof_type=proof_type,
+        )
+        board.add_chore(chore)
+        self._audit_log.record("guardian", "add_chore", f"{child_name}:{name}")
+        self._logger.log("chore_created", child=child_name, chore=name, value=float(chore.value))
+        return chore
+
+    def complete_chore(
+        self,
+        child_name: str,
+        name: str,
+        *,
+        proof: Optional[str] = None,
+        at: Optional[datetime] = None,
+    ) -> Decimal:
+        completion = self._chores[child_name].complete_chore(name, at=at, proof=proof)
+        metadata = {"chore": name, "multiplier": str(completion.multiplier)}
+        transaction = self.deposit(
+            child_name,
+            completion.awarded_value,
+            f"Chore completed: {name}",
+            category=EventCategory.CHORE,
+            metadata=metadata,
+        )
+        self._logger.log(
+            "chore_completed",
+            child=child_name,
+            chore=name,
+            awarded=float(completion.awarded_value),
+            multiplier=float(completion.multiplier),
+        )
+        self._webhooks.dispatch(
+            {
+                "event": "chore_completed",
+                "child": child_name,
+                "chore": name,
+                "value": float(completion.awarded_value),
+                "transaction_id": transaction.timestamp.isoformat(),
+            }
+        )
+        self.evaluate_badges(child_name)
+        return completion.awarded_value
+
+    def schedule_pack(
+        self,
+        child_name: str,
+        *,
+        name: str,
+        chore_names: Sequence[str],
+        bonus_value: AmountLike,
+        description: str = "",
+    ) -> ChorePack:
+        pack = ChorePack(name=name, chore_names=tuple(chore_names), bonus_value=to_decimal(bonus_value), description=description)
+        self._chores[child_name].schedule_pack(pack)
+        self._audit_log.record("guardian", "add_pack", f"{child_name}:{name}")
+        return pack
+
+    def complete_pack(self, child_name: str, name: str, *, at: Optional[datetime] = None) -> Decimal:
+        bonus = self._chores[child_name].complete_pack(name, at=at)
+        if bonus > Decimal("0"):
+            self.deposit(
+                child_name,
+                bonus,
+                f"Pack bonus: {name}",
+                category=EventCategory.BONUS,
+                metadata={"pack": name},
+            )
+        return bonus
+
+    def auto_republish_chores(self, *, at: Optional[datetime] = None) -> Dict[str, Sequence[str]]:
+        republished: Dict[str, Sequence[str]] = {}
+        for child, board in self._chores.items():
+            refreshed = board.auto_republish(at=at)
+            if refreshed:
+                republished[child] = refreshed
+        if republished:
+            self._logger.log("chores_republished", details=republished)
+        return republished
+
+    def send_pending_chore_alerts(
+        self,
+        *,
+        hours: int,
+        at: Optional[datetime] = None,
+    ) -> Sequence[Notification]:
+        alerts: list[Notification] = []
+        for child, board in self._chores.items():
+            overdue = board.pending_overdue(hours, at=at)
+            if not overdue:
+                continue
+            contact = self._parent_contacts.get(child, {})
+            recipient = contact.get("email") or contact.get("sms")
+            if not recipient:
+                continue
+            channel = NotificationChannel.EMAIL if contact.get("email") else NotificationChannel.SMS
+            for chore in overdue:
+                notification = Notification(
+                    recipient=recipient,
+                    channel=channel,
+                    type=NotificationType.CHORE_REMINDER,
+                    subject=f"{child} has a pending chore",
+                    body=f"Chore '{chore.name}' has been waiting since {chore.pending_since:%Y-%m-%d %H:%M}.",
+                    metadata={"child": child, "chore": chore.name},
+                )
+                self._notifications.queue(notification)
+                alerts.append(notification)
+        return tuple(alerts)
+
+    def evaluate_badges(self, child_name: str) -> Sequence[str]:
+        if not self._feature_flags.is_enabled("badges"):
+            return tuple(self._earned_badges.get(child_name, set()))
+        board = self._chores[child_name]
+        earned = self._earned_badges[child_name]
+        total_completions = board.total_completions()
+        for badge, threshold in self._badge_thresholds.items():
+            if total_completions >= threshold:
+                earned.add(badge)
+        for chore in board.chores():
+            if chore.streak >= 7:
+                earned.add("Streak Master")
+        return tuple(sorted(earned))
+
+    def leaderboard(self) -> Sequence[LeaderboardEntry]:
+        if not self._feature_flags.is_enabled("leaderboard"):
+            return tuple()
+        entries = [
+            LeaderboardEntry(name=child, score=board.leaderboard_score())
+            for child, board in self._chores.items()
+        ]
+        return tuple(sorted(entries, key=lambda entry: entry.score, reverse=True))
+
+    def goal_gallery(self, child_name: str) -> Sequence[dict]:
+        account = self.get_account(child_name)
+        return tuple(
+            {
+                "name": goal.name,
+                "progress": float(goal.progress()),
+                "image": goal.image_url,
+            }
+            for goal in account.goals
+        )
+
+    def record_nfc_tap(self, child_name: str, *, bonus: AmountLike = 0) -> NFCEvent:
+        bonus_amount = to_decimal(bonus)
+        event = NFCEvent(child_name=child_name, bonus_awarded=bonus_amount)
+        self._nfc_events.append(event)
+        if bonus_amount > Decimal("0"):
+            self.deposit(
+                child_name,
+                bonus_amount,
+                "NFC tap bonus",
+                category=EventCategory.BONUS,
+                metadata={"source": "nfc"},
+            )
+        return event
+
+    def nfc_log(self, child_name: Optional[str] = None) -> Sequence[NFCEvent]:
+        if child_name is None:
+            return tuple(self._nfc_events)
+        return tuple(event for event in self._nfc_events if event.child_name == child_name)
+
+    # ------------------------------------------------------------------
+    # Notifications, contacts and digests
+    # ------------------------------------------------------------------
+    @property
+    def notifications(self) -> NotificationCenter:
+        return self._notifications
+
+    def register_contacts(
+        self,
+        child_name: str,
+        *,
+        parent_email: str | None = None,
+        parent_sms: str | None = None,
+        kid_email: str | None = None,
+        kid_sms: str | None = None,
+    ) -> None:
+        if parent_email:
+            self._parent_contacts[child_name]["email"] = parent_email
+        if parent_sms:
+            self._parent_contacts[child_name]["sms"] = parent_sms
+        if kid_email:
+            self._kid_contacts[child_name]["email"] = kid_email
+        if kid_sms:
+            self._kid_contacts[child_name]["sms"] = kid_sms
+
+    def schedule_weekly_digest(
+        self,
+        recipient: str,
+        *,
+        summary: Mapping[str, object],
+        send_on: datetime,
+    ) -> None:
+        self._notifications.schedule_digest(
+            ScheduledDigest(recipient=recipient, send_on=send_on, summary=dict(summary))
+        )
+
+    # ------------------------------------------------------------------
+    # Payout approvals and exports
+    # ------------------------------------------------------------------
+    def set_soft_limit(self, child_name: str, amount: AmountLike) -> None:
+        self._soft_limits[child_name] = to_decimal(amount)
+
+    def request_payout(
+        self,
+        child_name: str,
+        amount: AmountLike,
+        *,
+        description: str,
+        requested_by: str,
+    ) -> PayoutRequest:
+        value = to_decimal(amount)
+        limit = self._soft_limits.get(child_name, self._default_soft_limit)
+        if value <= limit:
+            transaction = self.withdraw(
+                child_name,
+                value,
+                description,
+                category=EventCategory.MANUAL,
+                metadata={"approved": "auto"},
+            )
+            self._logger.log("payout_auto", child=child_name, amount=float(transaction.amount))
+            return PayoutRequest(
+                request_id="auto",
+                child_name=child_name,
+                amount=value,
+                description=description,
+                created_by=requested_by,
+                status=PayoutStatus.APPROVED,
+                resolved_at=datetime.utcnow(),
+                resolved_by="system",
+            )
+        request = PayoutRequest(
+            request_id=str(uuid4()),
+            child_name=child_name,
+            amount=value,
+            description=description,
+            created_by=requested_by,
+        )
+        self._pending_payouts[request.request_id] = request
+        self._audit_log.record(requested_by, "request_payout", f"{child_name}:{value}")
+        self._logger.log("payout_requested", child=child_name, amount=float(value))
+        return request
+
+    def approve_payout(self, request_id: str, *, approver: str) -> PayoutRequest:
+        request = self._pending_payouts[request_id]
+        request.approve(approver)
+        self.withdraw(
+            request.child_name,
+            request.amount,
+            request.description,
+            category=EventCategory.MANUAL,
+            metadata={"payout_request": request_id},
+        )
+        self._audit_log.record(approver, "approve_payout", request.child_name)
+        self._pending_payouts.pop(request_id, None)
+        return request
+
+    def reject_payout(self, request_id: str, *, approver: str) -> PayoutRequest:
+        request = self._pending_payouts[request_id]
+        request.reject(approver)
+        self._audit_log.record(approver, "reject_payout", request.child_name)
+        self._pending_payouts.pop(request_id, None)
+        return request
+
+    def pending_payouts(self) -> Sequence[PayoutRequest]:
+        return tuple(self._pending_payouts.values())
+
+    def bulk_approve_payouts(self, request_ids: Sequence[str], *, approver: str) -> Sequence[str]:
+        approved: list[str] = []
+        for request_id in request_ids:
+            if request_id in self._pending_payouts:
+                self.approve_payout(request_id, approver=approver)
+                approved.append(request_id)
+        return tuple(approved)
+
+    def export_transactions_csv(
+        self,
+        child_name: str,
+        *,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+        category: EventCategory | None = None,
+    ) -> str:
+        return self.get_account(child_name).export_transactions_csv(start=start, end=end, category=category)
+
+    def search_transactions(
+        self,
+        *,
+        child: str | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        categories: Sequence[EventCategory] | None = None,
+        types: Sequence[TransactionType] | None = None,
+    ) -> Sequence[tuple[str, Transaction]]:
+        names = [child] if child else self.list_accounts()
+        results: list[tuple[str, Transaction]] = []
+        for name in names:
+            account = self.get_account(name)
+            for transaction in account.filter_transactions(start=start, end=end, categories=categories, types=types):
+                results.append((name, transaction))
+        return tuple(results)
+
+    def bulk_deactivate_chores(self, child_name: str, names: Sequence[str]) -> Sequence[str]:
+        board = self._chores[child_name]
+        removed: list[str] = []
+        for chore_name in names:
+            if chore_name in {chore.name for chore in board.chores()}:
+                board.remove_chore(chore_name)
+                removed.append(chore_name)
+        if removed:
+            self._audit_log.record("guardian", "remove_chore", f"{child_name}:{','.join(removed)}")
+        return tuple(removed)
+
+    # ------------------------------------------------------------------
+    # Dashboard summaries and undo support
+    # ------------------------------------------------------------------
+    def kid_summary(self, child_name: str) -> KidSummary:
+        board = self._chores[child_name]
+        account = self.get_account(child_name)
+        last_payout = account.last_transaction(transaction_type=TransactionType.DEPOSIT)
+        pending = len(board.pending())
+        return KidSummary(
+            completion_percentage=board.completion_rate(),
+            last_payout=last_payout.timestamp if last_payout else None,
+            next_allowance_eta=self._next_allowance_eta.get(child_name),
+            pending_chores=pending,
+        )
+
+    def set_next_allowance_eta(self, child_name: str, eta: Optional[datetime]) -> None:
+        self._next_allowance_eta[child_name] = eta
+
+    def undo_last_event(self) -> str:
+        return self._undo.undo()
+
+    # ------------------------------------------------------------------
+    # Investing helpers
+    # ------------------------------------------------------------------
+    def portfolio(self, child_name: str) -> InvestmentPortfolio:
+        return self._portfolios[child_name]
+
+    def run_investing_jobs(self, *, at: Optional[datetime] = None) -> Dict[str, Decimal]:
+        invested: Dict[str, Decimal] = {}
+        for child, portfolio in self._portfolios.items():
+            amount = portfolio.run_dca_if_due(at=at)
+            if amount > Decimal("0"):
+                invested[child] = amount
+                self._logger.log("dca_executed", child=child, amount=float(amount))
+        return invested
+
+    # ------------------------------------------------------------------
+    # Ops & integrations
+    # ------------------------------------------------------------------
+    @property
+    def auth(self) -> AuthManager:
+        return self._auth
+
+    @property
+    def feature_flags(self) -> FeatureFlagRegistry:
+        return self._feature_flags
+
+    @property
+    def audit_log(self) -> AuditLog:
+        return self._audit_log
+
+    @property
+    def backup_manager(self) -> BackupManager:
+        return self._backups
+
+    @property
+    def health_monitor(self) -> HealthMonitor:
+        return self._health
+
+    @property
+    def logger(self) -> StructuredLogger:
+        return self._logger
+
+    @property
+    def translator(self) -> Translator:
+        return self._translator
+
+    def create_backup(self, *, label: str = "") -> BackupMetadata:
+        payload = {
+            "accounts": {
+                name: {
+                    "balance": float(account.balance),
+                    "escrow": float(account.escrow_balance),
+                    "goals": [goal.name for goal in account.goals],
+                }
+                for name, account in self._accounts.items()
+            }
+        }
+        return self._backups.create_backup(payload, label=label)
+
+    def health_status(self) -> dict:
+        return self._health.status()
+
+    def register_webhook(self, listener: Callable[[Dict[str, object]], None]) -> None:
+        self._webhooks.register(listener)
+
+    def api_account(self, child_name: str) -> dict:
+        return self._api.account_snapshot(self.get_account(child_name))
+
+    def translate(self, key: str, *, locale: Optional[str] = None) -> str:
+        return self._translator.translate(key, locale=locale)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _after_transaction(self, child_name: str, transaction: Transaction) -> None:
+        self._logger.log(
+            "transaction",
+            child=child_name,
+            type=transaction.type.value,
+            category=transaction.category.value if transaction.category else None,
+            amount=float(transaction.amount),
+        )
+        self._webhooks.dispatch(
+            {
+                "event": "transaction",
+                "child": child_name,
+                "type": transaction.type.value,
+                "amount": float(transaction.amount),
+                "category": transaction.category.value if transaction.category else None,
+                "timestamp": transaction.timestamp.isoformat(),
+            }
+        )
+        self._register_undo(child_name, transaction)
+
+    def _register_undo(self, child_name: str, transaction: Transaction) -> None:
+        account = self.get_account(child_name)
+        if transaction.type is TransactionType.DEPOSIT:
+            self._undo.register(
+                lambda: account.withdraw(
+                    transaction.amount,
+                    description=f"Undo {transaction.description}",
+                    category=transaction.category,
+                )
+            )
+        elif transaction.type is TransactionType.WITHDRAWAL:
+            self._undo.register(
+                lambda: account.deposit(
+                    transaction.amount,
+                    description=f"Undo {transaction.description}",
+                    category=transaction.category,
+                )
+            )
+
+    def _notify_payout(self, child_name: str, transaction: Transaction) -> None:
+        contact = self._kid_contacts.get(child_name, {})
+        recipient = contact.get("email") or contact.get("sms")
+        if not recipient:
+            return
+        channel = NotificationChannel.EMAIL if contact.get("email") else NotificationChannel.SMS
+        notification = Notification(
+            recipient=recipient,
+            channel=channel,
+            type=NotificationType.PAYOUT_POSTED,
+            subject="Allowance arrived!",
+            body=f"{format_currency(transaction.amount)} was added to your account.",
+            metadata={"child": child_name},
+        )
+        self._notifications.queue(notification)
+
+    def _check_goal_milestones(self, child_name: str, goal: Goal) -> None:
+        key = (child_name, goal.name)
+        milestones = self._goal_milestones[key]
+        for percentage in (25, 50, 75, 100):
+            if percentage in milestones:
+                continue
+            if goal.milestone_reached(percentage):
+                milestones.add(percentage)
+                contact = self._kid_contacts.get(child_name, {})
+                recipient = contact.get("email") or contact.get("sms")
+                if recipient:
+                    channel = NotificationChannel.EMAIL if contact.get("email") else NotificationChannel.SMS
+                    notification = Notification(
+                        recipient=recipient,
+                        channel=channel,
+                        type=NotificationType.GOAL_MILESTONE,
+                        subject=f"{percentage}% milestone reached!",
+                        body=f"Goal '{goal.name}' is now {percentage}% funded.",
+                        metadata={"child": child_name, "goal": goal.name, "milestone": str(percentage)},
+                    )
+                    self._notifications.queue(notification)
+
+
+__all__ = ["KidBank"]


### PR DESCRIPTION
## Summary
- extend models, accounts, and services with categorized transactions, goal milestones, payout approvals, dashboards, and CSV exports
- add dedicated modules for chores, notifications, investing, security/auth, admin audit logging, structured ops tooling, API/webhooks, email, and i18n support
- expose new helpers from the package namespace for integration points, feature flags, and gamified kid experiences

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d18d3f05d0832e8947083ae073f388