### PR TITLE
Enhance web app with transfers, CD investing, and statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ and rewards in an easy-to-read and fully tested code base.
   progress with percentage calculations.
 - **Comprehensive statements** – generate readable account summaries that list
   recent activity, goals, and rewards.
+- **Investing** – simulate portfolios with certificates of deposit that earn
+  interest at an adjustable rate.
 - **Test coverage** – unit tests exercise the core behaviours to keep the
   system reliable.
 

--- a/src/kidbank/__init__.py
+++ b/src/kidbank/__init__.py
@@ -13,7 +13,7 @@ from .exceptions import (
     KidBankError,
 )
 from .i18n import Translator
-from .investing import InvestmentPortfolio
+from .investing import CertificateOfDeposit, InvestmentPortfolio
 from .models import (
     BackupMetadata,
     EventCategory,
@@ -58,6 +58,7 @@ __all__ = [
     "NotificationCenter",
     "NotificationChannel",
     "NotificationType",
+    "CertificateOfDeposit",
     "InvestmentPortfolio",
     "ScheduledDigest",
     "Reward",

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -86,3 +86,21 @@ def test_transfer_moves_funds_between_accounts() -> None:
 
     with pytest.raises(InsufficientFundsError):
         giver.transfer_to(receiver, 100)
+
+
+def test_generate_statement_includes_goals_and_rewards() -> None:
+    account = Account("Ava")
+    account.deposit(Decimal("30.00"), "Weekly allowance")
+    account.add_goal("Bicycle", 100, description="Big goal for summer")
+    account.contribute_to_goal("Bicycle", Decimal("20.00"))
+    account.redeem_reward("Sticker pack", 3)
+
+    statement = account.generate_statement()
+
+    assert "Account holder: Ava" in statement
+    assert "Recent transactions:" in statement
+    assert "Savings goals:" in statement
+    assert "Bicycle" in statement
+    assert "20.0%" in statement  # 20 / 100 saved
+    assert "Redeemed rewards:" in statement
+    assert "Sticker pack" in statement


### PR DESCRIPTION
## Summary
- add certificate-of-deposit helpers and expose them in kid investing UI with open/mature endpoints
- extend admin dashboard with transfer form, CD rate controls, and richer goal progress displays
- provide an admin statement page summarising balances, goals, rewards, and investing activity

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1b59193d8832e8d7df2ca2c102abc