### PR TITLE
Restore cash balance when closing certificates

### DIFF
--- a/src/kidbank/investing.py
+++ b/src/kidbank/investing.py
@@ -226,6 +226,7 @@ class InvestmentPortfolio:
             accrued_interest = max(Decimal("0.00"), gross - certificate.principal)
             penalty = min(penalty, accrued_interest)
         net = (gross - penalty).quantize(Decimal("0.01"))
+        self.positions["cash"] = (self.positions["cash"] + net).quantize(Decimal("0.01"))
         gross = gross.quantize(Decimal("0.01"))
         penalty = penalty.quantize(Decimal("0.01"))
         return gross, penalty, net

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -115,6 +115,8 @@ def test_certificate_term_rates_and_penalties() -> None:
 
     opened_on = datetime.utcnow() - timedelta(days=60)
     certificate = bank.open_certificate("Ava", 100, term_months=6, opened_on=opened_on)
+    portfolio = bank.portfolio("Ava")
+    cash_before = portfolio.available_cash()
     assert certificate.rate == Decimal("0.0300")
 
     # Update rates for future certificates but existing one should remain unchanged
@@ -128,6 +130,7 @@ def test_certificate_term_rates_and_penalties() -> None:
     assert gross == Decimal("101.50")
     assert penalty == Decimal("0.50")
     assert net == Decimal("101.00")
+    assert portfolio.available_cash() == cash_before + net
     account = bank.get_account("Ava")
     deposit_tx, penalty_tx = account.transactions[-2:]
     assert deposit_tx.category is EventCategory.INVEST


### PR DESCRIPTION
## Summary
- credit closed certificate proceeds back to the portfolio cash balance
- extend the certificate withdrawal test to ensure available cash increases by the redeemed net amount

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1f420891c832e89c40a2b55126f0c