### PR TITLE
Allow updating parent PINs from admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,13 @@ stock-investing simulator described in the feature list.
 2. (Optional) create a `.env` file with custom PINs and session secret:
 
    ```env
-   MOM_PIN=1234
-   DAD_PIN=9876
+   MOM_PIN=1022
+   DAD_PIN=2097
    SESSION_SECRET=replace-me
    ```
+
+   PINs can also be updated later from the Admin → Parent PINs card; any
+   changes are stored in SQLite and override these defaults immediately.
 
 3. Launch the app:
 


### PR DESCRIPTION
## Summary
- store parent PIN overrides in SQLite and resolve admin roles using the latest values
- add an admin portal card and endpoint for updating parent PINs, plus README guidance about overrides

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d204de71b8832e81f796a291125822