### PR TITLE
Make kid investing charts responsive

### DIFF
--- a/src/kidbank/webapp.py
+++ b/src/kidbank/webapp.py
@@ -1063,8 +1063,8 @@ def base_styles() -> str:
         font-family: system-ui,-apple-system,Segoe UI,Roboto,Arial;
         background:var(--bg); color:var(--text);
         max-width:1320px;
-        margin:24px auto;
-        padding:0 16px;
+        margin:0 auto;
+        padding:24px 16px;
       }
       .layout{display:grid; grid-template-columns:220px 1fr; gap:16px; align-items:flex-start;}
       .layout .content{min-width:0;}


### PR DESCRIPTION
## Summary
- allow kid investing grid cards to shrink without introducing extra scrollbars
- render sparkline and detailed charts with responsive SVG attributes so they fit narrower screens

## Testing
- python -m pytest *(fails: missing fastapi dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d531310c58832e9027e89c940a5590