### PR TITLE
Stop investing page from scrolling

### DIFF
--- a/src/kidbank/webapp.py
+++ b/src/kidbank/webapp.py
@@ -6123,7 +6123,15 @@ def kid_invest_home(
         <p class='muted' style='margin-top:10px;'><a href='/kid'>← Back to My Account</a></p>
         {chart_modal_html}
         """
-        return render_page(request, f"Investing — {instrument_label}", inner)
+        invest_styles = "<style>body[data-page='kid-invest']{overflow:hidden;}</style>"
+        body_attrs = f"{body_pref_attrs(request)} data-page='kid-invest'"
+        html = frame(
+            f"Investing — {instrument_label}",
+            inner,
+            head_extra=invest_styles,
+            body_attrs=body_attrs,
+        )
+        return HTMLResponse(html)
     except Exception:
         body = """
         <div class='card'>


### PR DESCRIPTION
## Summary
- tag the investing kid dashboard with a page-specific body attribute
- inject inline CSS to hide overflow for that page so the scroll bar disappears

## Testing
- pytest *(fails: missing fastapi/starlette dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5359ecc50832e87d60109bf2bec2a