### PR TITLE
Add back button to kid investing dashboard

### DIFF
--- a/src/kidbank/webapp.py
+++ b/src/kidbank/webapp.py
@@ -6056,7 +6056,7 @@ def kid_invest_home(
         """
 
         inner = f"""
-        {notice_html}{search_card_html}
+        {notice_html}<div style='margin-bottom:10px;'><a href='/kid' class='button-link secondary'>← Back to My Account</a></div>{search_card_html}
         {tabs_html}
         <div class='card'>
           <h3>Investing — {instrument_label}</h3>


### PR DESCRIPTION
## Summary
- add a back-to-account button at the top of the kid investing dashboard

## Testing
- pytest *(fails: missing fastapi/starlette dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d538cc0218832e8eabe0f77d955d4a