### PR TITLE
Refactor webapp into package and add optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ stock-investing simulator described in the feature list.
 1. Install the optional web dependencies:
 
    ```bash
-   pip install fastapi uvicorn sqlmodel python-dotenv
+   pip install -r requirements-web.txt
    ```
 
 2. (Optional) create a `.env` file with custom PINs and session secret:

--- a/requirements-web.txt
+++ b/requirements-web.txt
@@ -1,0 +1,7 @@
+fastapi>=0.100
+uvicorn>=0.22
+sqlmodel>=0.0.8
+python-dotenv>=1.0
+itsdangerous>=2.1
+httpx>=0.24
+python-multipart>=0.0.6

--- a/src/kidbank/webapp/__init__.py
+++ b/src/kidbank/webapp/__init__.py
@@ -1,0 +1,42 @@
+"""KidBank web application package with optional dependencies."""
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any, List
+
+_OPTIONAL_IMPORT_ERROR: ModuleNotFoundError | None = None
+_IMPL_MODULE: ModuleType | None = None
+
+_OPTIONAL_MODULES = {"fastapi", "starlette", "sqlmodel", "sqlalchemy", "dotenv"}
+
+
+def _load_impl() -> ModuleType:
+    global _IMPL_MODULE, _OPTIONAL_IMPORT_ERROR
+    if _IMPL_MODULE is not None:
+        return _IMPL_MODULE
+    try:
+        _IMPL_MODULE = import_module(".application", __name__)
+        return _IMPL_MODULE
+    except ModuleNotFoundError as exc:  # pragma: no cover - defensive guard
+        if exc.name in _OPTIONAL_MODULES:
+            _OPTIONAL_IMPORT_ERROR = exc
+            raise RuntimeError(
+                "kidbank.webapp requires optional FastAPI/SQLModel dependencies. "
+                "Install them via `pip install -r requirements-web.txt` or the web extra."
+            ) from exc
+        raise
+
+
+def __getattr__(name: str) -> Any:
+    module = _load_impl()
+    return getattr(module, name)
+
+
+def __dir__() -> List[str]:
+    try:
+        module = _load_impl()
+    except RuntimeError:
+        return sorted(list(globals().keys()))
+    return sorted(set(globals()) | set(dir(module)))
+

--- a/src/kidbank/webapp/application.py
+++ b/src/kidbank/webapp/application.py
@@ -1,16 +1,10 @@
 """FastAPI frontend for the KidBank playground project.
 
-This module bundles a self-contained web UI that exposes the rich KidBank
-feature set (chores, allowances, investing simulator, prizes, ledgers, etc.)
-using SQLite for persistence.  It mirrors the functional requirements from the
-reference snippet provided by the user while fitting into the existing Python
-package so that it can be deployed in a Debian-based Proxmox LXC container with
-minimal effort.
-
-The implementation intentionally keeps the code in a single module so it can be
-Easily served with ``uvicorn kidbank.webapp:app``.  For larger deployments the
-components could be split into packages, but a single module keeps installation
-straight-forward for the target environment.
+The web application exposes a rich KidBank feature set (chores, allowances,
+investing simulator, prizes, ledgers, etc.) using SQLite for persistence.  The
+module is backed by dedicated configuration and persistence submodules so the
+codebase is easier to navigate while remaining import-compatible with
+``kidbank.webapp`` for ``uvicorn kidbank.webapp:app`` deployments.
 """
 
 from __future__ import annotations
@@ -23,9 +17,7 @@ import hmac
 import io
 import json
 import math
-import os
 import re
-import sqlite3
 import statistics
 import textwrap
 from dataclasses import dataclass, field
@@ -37,117 +29,34 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request as URLRequest, urlopen
 
-from dotenv import load_dotenv
 from fastapi import FastAPI, Form, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse, JSONResponse, Response
 from sqlalchemy import inspect
-from sqlalchemy.exc import OperationalError, ProgrammingError
-from sqlmodel import Field, Session, SQLModel, create_engine, desc, select
+from sqlmodel import Session, desc, select
 from starlette.middleware.sessions import SessionMiddleware
 
-load_dotenv()
-
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
-MOM_PIN = os.environ.get("MOM_PIN", "1022")
-DAD_PIN = os.environ.get("DAD_PIN", "2097")
-SESSION_SECRET = os.environ.get("SESSION_SECRET", "change-this-session-secret")
-SQLITE_FILE_NAME = os.environ.get("KIDBANK_SQLITE", "kidbank.db")
-DEFAULT_PARENT_ROLES: Tuple[str, ...] = ("mom", "dad")
-DEFAULT_PARENT_LABELS: Dict[str, str] = {"mom": "Mom", "dad": "Dad"}
-EXTRA_PARENT_ADMINS_KEY = "parent_admins"
-GLOBAL_CHORE_TYPES: Tuple[str, ...] = ("daily", "weekly", "monthly")
-DEFAULT_GLOBAL_CHORE_TYPE = "daily"
-PWA_CACHE_NAME = "kidbank-shell-v1"
-PWA_SHELL_PATHS: Tuple[str, ...] = (
-    "/",
-    "/kid",
-    "/admin",
-    "/admin/login",
-    "/manifest.webmanifest",
-    "/pwa-icon.svg",
-    "/offline",
+from .config import (
+    DAD_PIN,
+    DEFAULT_GLOBAL_CHORE_TYPE,
+    DEFAULT_PARENT_LABELS,
+    DEFAULT_PARENT_ROLES,
+    EXTRA_PARENT_ADMINS_KEY,
+    GLOBAL_CHORE_TYPES,
+    MOM_PIN,
+    PWA_CACHE_NAME,
+    PWA_ICON_SVG,
+    PWA_SHELL_PATHS,
+    REMEMBER_COOKIE_LIFETIME,
+    REMEMBER_COOKIE_MAX_AGE,
+    REMEMBER_COOKIE_NAME,
+    REMEMBER_NAME_COOKIE,
+    SERVICE_WORKER_JS,
+    SESSION_SECRET,
+    SQLITE_FILE_NAME,
 )
-PWA_ICON_SVG = """
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'>
-  <defs>
-    <linearGradient id='grad' x1='0' x2='1' y1='0' y2='1'>
-      <stop offset='0%' stop-color='#2563eb'/>
-      <stop offset='100%' stop-color='#1d4ed8'/>
-    </linearGradient>
-  </defs>
-  <rect width='128' height='128' rx='28' ry='28' fill='url(#grad)'/>
-  <text x='64' y='82' font-size='64' font-family='Roboto, Arial, sans-serif' font-weight='700' fill='#f8fafc' text-anchor='middle'>K</text>
-</svg>
-"""
-SERVICE_WORKER_JS = (
-    textwrap.dedent(
-        """
-        const CACHE_NAME = '__CACHE_NAME__';
-        const OFFLINE_URLS = __OFFLINE_URLS__;
-
-        self.addEventListener('install', event => {
-          event.waitUntil(
-            caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS)).then(() => self.skipWaiting())
-          );
-        });
-
-        self.addEventListener('activate', event => {
-          event.waitUntil(
-            caches.keys().then(keys => Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))))
-          );
-          self.clients.claim();
-        });
-
-        async function fetchAndCache(request) {
-          try {
-            const response = await fetch(request);
-            if (!response || response.status !== 200 || response.type !== 'basic') {
-              return response;
-            }
-            const clone = response.clone();
-            caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
-            return response;
-          } catch (error) {
-            throw error;
-          }
-        }
-
-        self.addEventListener('fetch', event => {
-          if (event.request.method !== 'GET') {
-            return;
-          }
-          const request = event.request;
-          const url = new URL(request.url);
-          if (request.mode === 'navigate') {
-            event.respondWith(
-              fetchAndCache(request).catch(() => caches.match(request).then(resp => resp || caches.match('/offline')))
-            );
-            return;
-          }
-          if (OFFLINE_URLS.includes(url.pathname)) {
-            event.respondWith(
-              caches.match(request).then(resp => resp || fetchAndCache(request))
-            );
-            return;
-          }
-          event.respondWith(
-            fetchAndCache(request).catch(() => caches.match(request))
-          );
-        });
-        """
-    )
-    .strip()
-    .replace("__CACHE_NAME__", PWA_CACHE_NAME)
-    .replace("__OFFLINE_URLS__", json.dumps(list(PWA_SHELL_PATHS)))
-)
-
-
-REMEMBER_COOKIE_NAME = "kid_remember"
-REMEMBER_NAME_COOKIE = "kid_remember_name"
-REMEMBER_COOKIE_LIFETIME = timedelta(days=30)
-REMEMBER_COOKIE_MAX_AGE = int(REMEMBER_COOKIE_LIFETIME.total_seconds())
+from . import persistence as _persistence
+from .persistence import *  # noqa: F401,F403
+from .persistence import _safe_marketplace_first, _safe_marketplace_list
 
 
 # ---------------------------------------------------------------------------
@@ -170,545 +79,6 @@ def now_local() -> datetime:
 
     return _time_provider()
 
-
-# ---------------------------------------------------------------------------
-# Database models
-# ---------------------------------------------------------------------------
-engine = create_engine(
-    f"sqlite:///{SQLITE_FILE_NAME}",
-    echo=False,
-    connect_args={"check_same_thread": False},
-)
-
-# Ensure fresh metadata when re-importing in test contexts.
-SQLModel.metadata.clear()
-
-
-if getattr(Session.__init__, "__name__", "") != "_session_init_no_expire":
-    _SESSION_INIT = Session.__init__
-
-    def _session_init_no_expire(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple wrapper
-        if "expire_on_commit" not in kwargs:
-            kwargs["expire_on_commit"] = False
-        _SESSION_INIT(self, *args, **kwargs)
-
-    Session.__init__ = _session_init_no_expire  # type: ignore[assignment]
-
-
-class Child(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    kid_id: str
-    name: str
-    balance_cents: int = 0
-    kid_pin: Optional[str] = ""
-    allowance_cents: int = 0
-    notes: Optional[str] = None
-    streak_days: int = 0
-    badges: Optional[str] = ""
-    level: int = 1
-    total_points: int = 0
-    last_chore_date: Optional[date] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
-
-
-class Event(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    child_id: str
-    change_cents: int
-    reason: str
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
-
-
-class MoneyRequest(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    from_kid_id: str
-    to_kid_id: str
-    amount_cents: int
-    reason: str = ""
-    status: str = "pending"  # pending|accepted|declined
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    resolved_at: Optional[datetime] = None
-
-
-class Prize(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    name: str
-    cost_cents: int
-    notes: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-
-
-ChoreType = Literal["daily", "weekly", "special", "global"]
-
-
-class Chore(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    kid_id: str
-    name: str
-    type: str  # daily|weekly|special|global
-    award_cents: int
-    notes: Optional[str] = None
-    active: bool = True
-    start_date: Optional[date] = None
-    end_date: Optional[date] = None
-    max_claimants: int = 1
-    weekdays: Optional[str] = None
-    specific_dates: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-
-
-class ChoreInstance(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    chore_id: int
-    period_key: str  # daily: YYYY-MM-DD; weekly: <SundayISO>-WEEK; special: SPECIAL
-    status: str = "available"  # available|pending|pending_marketplace|paid
-    completed_at: Optional[datetime] = None
-    paid_event_id: Optional[int] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-
-
-CHORE_STATUS_PENDING_MARKETPLACE = "pending_marketplace"
-
-
-MARKETPLACE_STATUS_OPEN = "open"
-MARKETPLACE_STATUS_CLAIMED = "claimed"
-MARKETPLACE_STATUS_SUBMITTED = "submitted"
-MARKETPLACE_STATUS_COMPLETED = "completed"
-MARKETPLACE_STATUS_CANCELLED = "cancelled"
-MARKETPLACE_STATUS_REJECTED = "rejected"
-
-
-
-class MarketplaceListing(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    owner_kid_id: str
-    chore_id: int
-    chore_name: str
-    chore_award_cents: int
-    offer_cents: int
-    status: str = Field(default=MARKETPLACE_STATUS_OPEN)
-    claimed_by: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    claimed_at: Optional[datetime] = None
-    submitted_at: Optional[datetime] = None
-    completed_at: Optional[datetime] = None
-    cancelled_at: Optional[datetime] = None
-    final_payout_cents: Optional[int] = None
-    payout_note: Optional[str] = None
-    resolved_by: Optional[str] = None
-    payout_event_id: Optional[int] = None
-
-
-
-class MetaKV(SQLModel, table=True):
-    k: str = Field(primary_key=True)
-    v: str
-
-
-class Goal(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    kid_id: str
-    name: str
-    target_cents: int
-    saved_cents: int = 0
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    achieved_at: Optional[datetime] = None
-
-
-class Certificate(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    kid_id: str
-    principal_cents: int
-    rate_bps: int
-    term_months: int
-    term_days: int = 0
-    opened_at: datetime = Field(default_factory=datetime.utcnow)
-    matured_at: Optional[datetime] = None
-    penalty_days: int = 0
-
-
-class Investment(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    kid_id: str
-    fund: str = "SP500"
-    shares: float = 0.0
-
-
-class InvestmentTx(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    kid_id: str
-    fund: str = "SP500"
-    ts: datetime = Field(default_factory=datetime.utcnow)
-    tx_type: str  # "buy" | "sell"
-    shares: float
-    price_cents: int
-    amount_cents: int
-    realized_pl_cents: int = 0
-
-
-class MarketInstrument(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    symbol: str
-    name: str
-    kind: str = "stock"  # stock|crypto
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-
-
-class KidMarketInstrument(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    kid_id: str
-    symbol: str
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-
-
-class GlobalChoreClaim(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    chore_id: int
-    kid_id: str
-    period_key: str
-    status: str = "pending"  # pending|approved|rejected
-    award_cents: int = 0
-    submitted_at: datetime = Field(default_factory=datetime.utcnow)
-    approved_at: Optional[datetime] = None
-    approved_by: Optional[str] = None
-    notes: Optional[str] = None
-
-
-class Lesson(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    title: str
-    content_md: str
-    summary: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-
-
-class Quiz(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    lesson_id: int
-    payload: str
-    reward_cents: int = 0
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-
-
-class QuizAttempt(SQLModel, table=True):
-    id: Optional[int] = Field(default=None, primary_key=True)
-    child_id: str
-    quiz_id: int
-    score: int = 0
-    max_score: int = 0
-    responses: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-
-
-GLOBAL_CHORE_KID_ID = "__GLOBAL__"
-GLOBAL_CHORE_STATUS_PENDING = "pending"
-GLOBAL_CHORE_STATUS_APPROVED = "approved"
-GLOBAL_CHORE_STATUS_REJECTED = "rejected"
-
-INSTRUMENT_KIND_STOCK = "stock"
-INSTRUMENT_KIND_CRYPTO = "crypto"
-DEFAULT_MARKET_SYMBOL = "SP500"
-
-TIME_MODE_AUTO = "auto"
-TIME_MODE_MANUAL = "manual"
-TIME_META_MODE_KEY = "time_mode"
-TIME_META_MANUAL_KEY = "time_manual_iso"
-TIME_META_OFFSET_KEY = "time_offset_minutes"
-TIME_META_MANUAL_REF_KEY = "time_manual_reference"
-
-
-# ---------------------------------------------------------------------------
-# Database initialisation & migrations
-# ---------------------------------------------------------------------------
-def create_db_and_tables() -> None:
-    SQLModel.metadata.create_all(engine)
-
-
-def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
-    cur = conn.execute(f"PRAGMA table_info({table});")
-    return any(row[1] == column for row in cur.fetchall())
-
-
-def _marketplace_error_needs_migration(exc: Exception) -> bool:
-    message = str(exc).lower()
-    return "marketplacelisting" in message and (
-        "no such table" in message
-        or "no such column" in message
-        or "has no column" in message
-    )
-
-
-def _safe_marketplace_list(session: Session, query) -> List[MarketplaceListing]:
-    try:
-        return session.exec(query).all()
-    except (sqlite3.OperationalError, OperationalError, ProgrammingError) as exc:
-        if _marketplace_error_needs_migration(exc):
-            run_migrations()
-            try:
-                return session.exec(query).all()
-            except (sqlite3.OperationalError, OperationalError, ProgrammingError) as retry_exc:
-                if _marketplace_error_needs_migration(retry_exc):
-                    return []
-                raise
-        raise
-
-
-def _safe_marketplace_first(session: Session, query) -> Optional[MarketplaceListing]:
-    try:
-        return session.exec(query).first()
-    except (sqlite3.OperationalError, OperationalError, ProgrammingError) as exc:
-        if _marketplace_error_needs_migration(exc):
-            run_migrations()
-            try:
-                return session.exec(query).first()
-            except (sqlite3.OperationalError, OperationalError, ProgrammingError) as retry_exc:
-                if _marketplace_error_needs_migration(retry_exc):
-                    return None
-                raise
-        raise
-
-
-def run_migrations() -> None:
-    raw = sqlite3.connect(SQLITE_FILE_NAME)
-    try:
-        if not _column_exists(raw, "child", "kid_pin"):
-            raw.execute("ALTER TABLE child ADD COLUMN kid_pin TEXT DEFAULT '';")
-        if not _column_exists(raw, "child", "allowance_cents"):
-            raw.execute("ALTER TABLE child ADD COLUMN allowance_cents INTEGER DEFAULT 0;")
-        if not _column_exists(raw, "child", "streak_days"):
-            raw.execute("ALTER TABLE child ADD COLUMN streak_days INTEGER DEFAULT 0;")
-        if not _column_exists(raw, "child", "badges"):
-            raw.execute("ALTER TABLE child ADD COLUMN badges TEXT DEFAULT '';")
-        if not _column_exists(raw, "child", "level"):
-            raw.execute("ALTER TABLE child ADD COLUMN level INTEGER DEFAULT 1;")
-        if not _column_exists(raw, "child", "total_points"):
-            raw.execute("ALTER TABLE child ADD COLUMN total_points INTEGER DEFAULT 0;")
-        if not _column_exists(raw, "child", "last_chore_date"):
-            raw.execute("ALTER TABLE child ADD COLUMN last_chore_date TEXT;")
-        if not _column_exists(raw, "chore", "start_date"):
-            raw.execute("ALTER TABLE chore ADD COLUMN start_date TEXT;")
-        if not _column_exists(raw, "chore", "end_date"):
-            raw.execute("ALTER TABLE chore ADD COLUMN end_date TEXT;")
-        if not _column_exists(raw, "choreinstance", "paid_event_id"):
-            raw.execute("ALTER TABLE choreinstance ADD COLUMN paid_event_id INTEGER;")
-        if not _column_exists(raw, "choreinstance", "created_at"):
-            raw.execute("ALTER TABLE choreinstance ADD COLUMN created_at TEXT;")
-        if not _column_exists(raw, "goal", "achieved_at"):
-            raw.execute("ALTER TABLE goal ADD COLUMN achieved_at TEXT;")
-        if not _column_exists(raw, "chore", "max_claimants"):
-            raw.execute("ALTER TABLE chore ADD COLUMN max_claimants INTEGER DEFAULT 1;")
-        if not _column_exists(raw, "chore", "weekdays"):
-            raw.execute("ALTER TABLE chore ADD COLUMN weekdays TEXT;")
-        if not _column_exists(raw, "chore", "specific_dates"):
-            raw.execute("ALTER TABLE chore ADD COLUMN specific_dates TEXT;")
-        if not _column_exists(raw, "certificate", "term_days"):
-            raw.execute("ALTER TABLE certificate ADD COLUMN term_days INTEGER DEFAULT 0;")
-            raw.execute(
-                """
-                UPDATE certificate
-                SET term_days = (
-                    CASE
-                        WHEN term_months IS NULL OR term_months < 0 THEN 0
-                        ELSE term_months * 30
-                    END
-                )
-                WHERE IFNULL(term_days, 0) = 0;
-                """
-            )
-        if not _column_exists(raw, "certificate", "penalty_days"):
-            raw.execute("ALTER TABLE certificate ADD COLUMN penalty_days INTEGER DEFAULT 0;")
-        raw.execute(
-            """
-            CREATE TABLE IF NOT EXISTS investment (
-                id INTEGER PRIMARY KEY,
-                kid_id TEXT,
-                fund TEXT,
-                shares REAL
-            );
-            """
-        )
-        raw.execute(
-            """
-            CREATE TABLE IF NOT EXISTS certificate (
-                id INTEGER PRIMARY KEY,
-                kid_id TEXT,
-                principal_cents INTEGER,
-                rate_bps INTEGER,
-                term_months INTEGER,
-                term_days INTEGER DEFAULT 0,
-                opened_at TEXT,
-                matured_at TEXT,
-                penalty_days INTEGER DEFAULT 0
-            );
-            """
-        )
-        raw.execute(
-            """
-            CREATE TABLE IF NOT EXISTS investmenttx (
-                id INTEGER PRIMARY KEY,
-                kid_id TEXT,
-                fund TEXT,
-                ts TEXT,
-                tx_type TEXT,
-                shares REAL,
-                price_cents INTEGER,
-                amount_cents INTEGER,
-                realized_pl_cents INTEGER
-            );
-            """
-        )
-        raw.execute(
-            """
-            CREATE TABLE IF NOT EXISTS marketinstrument (
-                id INTEGER PRIMARY KEY,
-                symbol TEXT,
-                name TEXT,
-                kind TEXT,
-                created_at TEXT
-            );
-            """
-        )
-        raw.execute(
-            """
-            CREATE TABLE IF NOT EXISTS kidmarketinstrument (
-                id INTEGER PRIMARY KEY,
-                kid_id TEXT,
-                symbol TEXT,
-                created_at TEXT
-            );
-            """
-        )
-        raw.execute(
-            """
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_kidmarketinstrument_kid_symbol
-            ON kidmarketinstrument(kid_id, symbol);
-            """
-        )
-        raw.execute(
-            """
-            INSERT OR IGNORE INTO kidmarketinstrument (kid_id, symbol, created_at)
-            SELECT DISTINCT kid_id, UPPER(fund), CURRENT_TIMESTAMP
-            FROM investment
-            WHERE IFNULL(kid_id, '') != '' AND IFNULL(fund, '') != '';
-            """
-        )
-        raw.execute(
-            """
-            CREATE TABLE IF NOT EXISTS globalchoreclaim (
-                id INTEGER PRIMARY KEY,
-                chore_id INTEGER,
-                kid_id TEXT,
-                period_key TEXT,
-                status TEXT,
-                award_cents INTEGER,
-                submitted_at TEXT,
-                approved_at TEXT,
-                approved_by TEXT,
-                notes TEXT
-            );
-            """
-        )
-        raw.execute(
-            """
-            CREATE TABLE IF NOT EXISTS lesson (
-                id INTEGER PRIMARY KEY,
-                title TEXT,
-                content_md TEXT,
-                summary TEXT,
-                created_at TEXT
-            );
-            """
-        )
-        raw.execute(
-            """
-            CREATE TABLE IF NOT EXISTS quiz (
-                id INTEGER PRIMARY KEY,
-                lesson_id INTEGER,
-                payload TEXT,
-                reward_cents INTEGER DEFAULT 0,
-                created_at TEXT
-            );
-            """
-        )
-        raw.execute(
-            """
-            CREATE TABLE IF NOT EXISTS quizattempt (
-                id INTEGER PRIMARY KEY,
-                child_id TEXT,
-                quiz_id INTEGER,
-                score INTEGER,
-                max_score INTEGER,
-                responses TEXT,
-                created_at TEXT
-            );
-            """
-        )
-        raw.execute(
-            """
-            CREATE TABLE IF NOT EXISTS marketplacelisting (
-                id INTEGER PRIMARY KEY,
-                owner_kid_id TEXT,
-                chore_id INTEGER,
-                chore_name TEXT,
-                chore_award_cents INTEGER,
-                offer_cents INTEGER,
-                status TEXT,
-                claimed_by TEXT,
-                created_at TEXT,
-                claimed_at TEXT,
-                submitted_at TEXT,
-                completed_at TEXT,
-                cancelled_at TEXT,
-                final_payout_cents INTEGER,
-                payout_note TEXT,
-                resolved_by TEXT,
-                payout_event_id INTEGER
-
-            );
-            """
-        )
-        raw.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_marketplace_owner_status
-            ON marketplacelisting(owner_kid_id, status);
-            """
-        )
-        raw.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_marketplace_status
-            ON marketplacelisting(status);
-            """
-        )
-
-        if not _column_exists(raw, "marketplacelisting", "submitted_at"):
-            raw.execute(
-                "ALTER TABLE marketplacelisting ADD COLUMN submitted_at TEXT;"
-            )
-        if not _column_exists(raw, "marketplacelisting", "final_payout_cents"):
-            raw.execute(
-                "ALTER TABLE marketplacelisting ADD COLUMN final_payout_cents INTEGER;"
-            )
-        if not _column_exists(raw, "marketplacelisting", "payout_note"):
-            raw.execute(
-                "ALTER TABLE marketplacelisting ADD COLUMN payout_note TEXT;"
-            )
-        if not _column_exists(raw, "marketplacelisting", "resolved_by"):
-            raw.execute(
-                "ALTER TABLE marketplacelisting ADD COLUMN resolved_by TEXT;"
-            )
-        if not _column_exists(raw, "marketplacelisting", "payout_event_id"):
-            raw.execute(
-                "ALTER TABLE marketplacelisting ADD COLUMN payout_event_id INTEGER;"
-            )
-
-        raw.commit()
-    finally:
-        raw.close()
-
-
-create_db_and_tables()
-run_migrations()
 
 
 # ---------------------------------------------------------------------------
@@ -10613,3 +9983,14 @@ def admin_ledger_csv(request: Request):
             writer.writerow([event.timestamp.isoformat(), event.child_id, event.change_cents / 100, event.reason])
     output.seek(0)
     return StreamingResponse(iter([output.getvalue()]), media_type="text/csv", headers={"Content-Disposition": "attachment; filename=ledger.csv"})
+
+
+__all__ = [
+    "app",
+    "detailed_history_chart_svg",
+    "list_kid_market_symbols",
+    "filter_events",
+    "ensure_default_learning_content",
+    "load_admin_privileges",
+]
+__all__.extend(name for name in _persistence.__all__ if name not in __all__)

--- a/src/kidbank/webapp/config.py
+++ b/src/kidbank/webapp/config.py
@@ -1,0 +1,137 @@
+"""Configuration constants for the KidBank web frontend."""
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from datetime import timedelta
+from typing import Dict, Tuple
+
+try:  # pragma: no cover - optional dependency guard
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover
+    def load_dotenv() -> None:  # type: ignore[override]
+        """Fallback when python-dotenv is not installed."""
+
+        return None
+else:  # pragma: no cover - simple passthrough
+    load_dotenv()
+
+MOM_PIN = os.environ.get("MOM_PIN", "1022")
+DAD_PIN = os.environ.get("DAD_PIN", "2097")
+SESSION_SECRET = os.environ.get("SESSION_SECRET", "change-this-session-secret")
+SQLITE_FILE_NAME = os.environ.get("KIDBANK_SQLITE", "kidbank.db")
+DEFAULT_PARENT_ROLES: Tuple[str, ...] = ("mom", "dad")
+DEFAULT_PARENT_LABELS: Dict[str, str] = {"mom": "Mom", "dad": "Dad"}
+EXTRA_PARENT_ADMINS_KEY = "parent_admins"
+GLOBAL_CHORE_TYPES: Tuple[str, ...] = ("daily", "weekly", "monthly")
+DEFAULT_GLOBAL_CHORE_TYPE = "daily"
+PWA_CACHE_NAME = "kidbank-shell-v1"
+PWA_SHELL_PATHS: Tuple[str, ...] = (
+    "/",
+    "/kid",
+    "/admin",
+    "/admin/login",
+    "/manifest.webmanifest",
+    "/pwa-icon.svg",
+    "/offline",
+)
+PWA_ICON_SVG = """
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'>
+  <defs>
+    <linearGradient id='grad' x1='0' x2='1' y1='0' y2='1'>
+      <stop offset='0%' stop-color='#2563eb'/>
+      <stop offset='100%' stop-color='#1d4ed8'/>
+    </linearGradient>
+  </defs>
+  <rect width='128' height='128' rx='28' ry='28' fill='url(#grad)'/>
+  <text x='64' y='82' font-size='64' font-family='Roboto, Arial, sans-serif' font-weight='700' fill='#f8fafc' text-anchor='middle'>K</text>
+</svg>
+"""
+SERVICE_WORKER_JS = (
+    textwrap.dedent(
+        """
+        const CACHE_NAME = '__CACHE_NAME__';
+        const OFFLINE_URLS = __OFFLINE_URLS__;
+
+        self.addEventListener('install', event => {
+          event.waitUntil(
+            caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS)).then(() => self.skipWaiting())
+          );
+        });
+
+        self.addEventListener('activate', event => {
+          event.waitUntil(
+            caches.keys().then(keys => Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))))
+          );
+          self.clients.claim();
+        });
+
+        async function fetchAndCache(request) {
+          try {
+            const response = await fetch(request);
+            if (!response || response.status !== 200 || response.type !== 'basic') {
+              return response;
+            }
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
+            return response;
+          } catch (error) {
+            throw error;
+          }
+        }
+
+        self.addEventListener('fetch', event => {
+          if (event.request.method !== 'GET') {
+            return;
+          }
+          const request = event.request;
+          const url = new URL(request.url);
+          if (request.mode === 'navigate') {
+            event.respondWith(
+              fetchAndCache(request).catch(() => caches.match(request).then(resp => resp || caches.match('/offline')))
+            );
+            return;
+          }
+          if (OFFLINE_URLS.includes(url.pathname)) {
+            event.respondWith(
+              caches.match(request).then(resp => resp || fetchAndCache(request))
+            );
+            return;
+          }
+          event.respondWith(
+            fetchAndCache(request).catch(() => caches.match(request))
+          );
+        });
+        """
+    )
+    .strip()
+    .replace("__CACHE_NAME__", PWA_CACHE_NAME)
+    .replace("__OFFLINE_URLS__", json.dumps(list(PWA_SHELL_PATHS)))
+)
+
+REMEMBER_COOKIE_NAME = "kid_remember"
+REMEMBER_NAME_COOKIE = "kid_remember_name"
+REMEMBER_COOKIE_LIFETIME = timedelta(days=30)
+REMEMBER_COOKIE_MAX_AGE = int(REMEMBER_COOKIE_LIFETIME.total_seconds())
+
+__all__ = [
+    "MOM_PIN",
+    "DAD_PIN",
+    "SESSION_SECRET",
+    "SQLITE_FILE_NAME",
+    "DEFAULT_PARENT_ROLES",
+    "DEFAULT_PARENT_LABELS",
+    "EXTRA_PARENT_ADMINS_KEY",
+    "GLOBAL_CHORE_TYPES",
+    "DEFAULT_GLOBAL_CHORE_TYPE",
+    "PWA_CACHE_NAME",
+    "PWA_SHELL_PATHS",
+    "PWA_ICON_SVG",
+    "SERVICE_WORKER_JS",
+    "REMEMBER_COOKIE_NAME",
+    "REMEMBER_NAME_COOKIE",
+    "REMEMBER_COOKIE_LIFETIME",
+    "REMEMBER_COOKIE_MAX_AGE",
+]
+

--- a/src/kidbank/webapp/persistence.py
+++ b/src/kidbank/webapp/persistence.py
@@ -1,0 +1,599 @@
+"""Persistence and SQLModel definitions for the KidBank web frontend."""
+from __future__ import annotations
+
+import sqlite3
+from datetime import date, datetime
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
+
+from sqlalchemy import inspect
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlmodel import Field, Session, SQLModel, create_engine, desc, select
+
+from .config import DEFAULT_GLOBAL_CHORE_TYPE, GLOBAL_CHORE_TYPES, SQLITE_FILE_NAME
+
+# ---------------------------------------------------------------------------
+# Database models
+# ---------------------------------------------------------------------------
+engine = create_engine(
+    f"sqlite:///{SQLITE_FILE_NAME}",
+    echo=False,
+    connect_args={"check_same_thread": False},
+)
+
+# Ensure fresh metadata when re-importing in test contexts.
+SQLModel.metadata.clear()
+
+
+if getattr(Session.__init__, "__name__", "") != "_session_init_no_expire":
+    _SESSION_INIT = Session.__init__
+
+    def _session_init_no_expire(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple wrapper
+        if "expire_on_commit" not in kwargs:
+            kwargs["expire_on_commit"] = False
+        _SESSION_INIT(self, *args, **kwargs)
+
+    Session.__init__ = _session_init_no_expire  # type: ignore[assignment]
+
+
+class Child(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    kid_id: str
+    name: str
+    balance_cents: int = 0
+    kid_pin: Optional[str] = ""
+    allowance_cents: int = 0
+    notes: Optional[str] = None
+    streak_days: int = 0
+    badges: Optional[str] = ""
+    level: int = 1
+    total_points: int = 0
+    last_chore_date: Optional[date] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Event(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    child_id: str
+    change_cents: int
+    reason: str
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+class MoneyRequest(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    from_kid_id: str
+    to_kid_id: str
+    amount_cents: int
+    reason: str = ""
+    status: str = "pending"  # pending|accepted|declined
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    resolved_at: Optional[datetime] = None
+
+
+class Prize(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    cost_cents: int
+    notes: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+ChoreType = Literal["daily", "weekly", "special", "global"]
+
+
+class Chore(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    kid_id: str
+    name: str
+    type: str  # daily|weekly|special|global
+    award_cents: int
+    notes: Optional[str] = None
+    active: bool = True
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    max_claimants: int = 1
+    weekdays: Optional[str] = None
+    specific_dates: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ChoreInstance(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    chore_id: int
+    period_key: str  # daily: YYYY-MM-DD; weekly: <SundayISO>-WEEK; special: SPECIAL
+    status: str = "available"  # available|pending|pending_marketplace|paid
+    completed_at: Optional[datetime] = None
+    paid_event_id: Optional[int] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+CHORE_STATUS_PENDING_MARKETPLACE = "pending_marketplace"
+
+
+MARKETPLACE_STATUS_OPEN = "open"
+MARKETPLACE_STATUS_CLAIMED = "claimed"
+MARKETPLACE_STATUS_SUBMITTED = "submitted"
+MARKETPLACE_STATUS_COMPLETED = "completed"
+MARKETPLACE_STATUS_CANCELLED = "cancelled"
+MARKETPLACE_STATUS_REJECTED = "rejected"
+
+
+
+class MarketplaceListing(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    owner_kid_id: str
+    chore_id: int
+    chore_name: str
+    chore_award_cents: int
+    offer_cents: int
+    status: str = Field(default=MARKETPLACE_STATUS_OPEN)
+    claimed_by: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    claimed_at: Optional[datetime] = None
+    submitted_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    cancelled_at: Optional[datetime] = None
+    final_payout_cents: Optional[int] = None
+    payout_note: Optional[str] = None
+    resolved_by: Optional[str] = None
+    payout_event_id: Optional[int] = None
+
+
+
+class MetaKV(SQLModel, table=True):
+    k: str = Field(primary_key=True)
+    v: str
+
+
+class Goal(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    kid_id: str
+    name: str
+    target_cents: int
+    saved_cents: int = 0
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    achieved_at: Optional[datetime] = None
+
+
+class Certificate(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    kid_id: str
+    principal_cents: int
+    rate_bps: int
+    term_months: int
+    term_days: int = 0
+    opened_at: datetime = Field(default_factory=datetime.utcnow)
+    matured_at: Optional[datetime] = None
+    penalty_days: int = 0
+
+
+class Investment(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    kid_id: str
+    fund: str = "SP500"
+    shares: float = 0.0
+
+
+class InvestmentTx(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    kid_id: str
+    fund: str = "SP500"
+    ts: datetime = Field(default_factory=datetime.utcnow)
+    tx_type: str  # "buy" | "sell"
+    shares: float
+    price_cents: int
+    amount_cents: int
+    realized_pl_cents: int = 0
+
+
+class MarketInstrument(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    symbol: str
+    name: str
+    kind: str = "stock"  # stock|crypto
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class KidMarketInstrument(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    kid_id: str
+    symbol: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class GlobalChoreClaim(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    chore_id: int
+    kid_id: str
+    period_key: str
+    status: str = "pending"  # pending|approved|rejected
+    award_cents: int = 0
+    submitted_at: datetime = Field(default_factory=datetime.utcnow)
+    approved_at: Optional[datetime] = None
+    approved_by: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class Lesson(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    content_md: str
+    summary: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Quiz(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    lesson_id: int
+    payload: str
+    reward_cents: int = 0
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class QuizAttempt(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    child_id: str
+    quiz_id: int
+    score: int = 0
+    max_score: int = 0
+    responses: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+GLOBAL_CHORE_KID_ID = "__GLOBAL__"
+GLOBAL_CHORE_STATUS_PENDING = "pending"
+GLOBAL_CHORE_STATUS_APPROVED = "approved"
+GLOBAL_CHORE_STATUS_REJECTED = "rejected"
+
+INSTRUMENT_KIND_STOCK = "stock"
+INSTRUMENT_KIND_CRYPTO = "crypto"
+DEFAULT_MARKET_SYMBOL = "SP500"
+
+TIME_MODE_AUTO = "auto"
+TIME_MODE_MANUAL = "manual"
+TIME_META_MODE_KEY = "time_mode"
+TIME_META_MANUAL_KEY = "time_manual_iso"
+TIME_META_OFFSET_KEY = "time_offset_minutes"
+TIME_META_MANUAL_REF_KEY = "time_manual_reference"
+
+
+# ---------------------------------------------------------------------------
+# Database initialisation & migrations
+# ---------------------------------------------------------------------------
+def create_db_and_tables() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    cur = conn.execute(f"PRAGMA table_info({table});")
+    return any(row[1] == column for row in cur.fetchall())
+
+
+def _marketplace_error_needs_migration(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return "marketplacelisting" in message and (
+        "no such table" in message
+        or "no such column" in message
+        or "has no column" in message
+    )
+
+
+def _safe_marketplace_list(session: Session, query) -> List[MarketplaceListing]:
+    try:
+        return session.exec(query).all()
+    except (sqlite3.OperationalError, OperationalError, ProgrammingError) as exc:
+        if _marketplace_error_needs_migration(exc):
+            run_migrations()
+            try:
+                return session.exec(query).all()
+            except (sqlite3.OperationalError, OperationalError, ProgrammingError) as retry_exc:
+                if _marketplace_error_needs_migration(retry_exc):
+                    return []
+                raise
+        raise
+
+
+def _safe_marketplace_first(session: Session, query) -> Optional[MarketplaceListing]:
+    try:
+        return session.exec(query).first()
+    except (sqlite3.OperationalError, OperationalError, ProgrammingError) as exc:
+        if _marketplace_error_needs_migration(exc):
+            run_migrations()
+            try:
+                return session.exec(query).first()
+            except (sqlite3.OperationalError, OperationalError, ProgrammingError) as retry_exc:
+                if _marketplace_error_needs_migration(retry_exc):
+                    return None
+                raise
+        raise
+
+
+def run_migrations() -> None:
+    raw = sqlite3.connect(SQLITE_FILE_NAME)
+    try:
+        if not _column_exists(raw, "child", "kid_pin"):
+            raw.execute("ALTER TABLE child ADD COLUMN kid_pin TEXT DEFAULT '';")
+        if not _column_exists(raw, "child", "allowance_cents"):
+            raw.execute("ALTER TABLE child ADD COLUMN allowance_cents INTEGER DEFAULT 0;")
+        if not _column_exists(raw, "child", "streak_days"):
+            raw.execute("ALTER TABLE child ADD COLUMN streak_days INTEGER DEFAULT 0;")
+        if not _column_exists(raw, "child", "badges"):
+            raw.execute("ALTER TABLE child ADD COLUMN badges TEXT DEFAULT '';")
+        if not _column_exists(raw, "child", "level"):
+            raw.execute("ALTER TABLE child ADD COLUMN level INTEGER DEFAULT 1;")
+        if not _column_exists(raw, "child", "total_points"):
+            raw.execute("ALTER TABLE child ADD COLUMN total_points INTEGER DEFAULT 0;")
+        if not _column_exists(raw, "child", "last_chore_date"):
+            raw.execute("ALTER TABLE child ADD COLUMN last_chore_date TEXT;")
+        if not _column_exists(raw, "chore", "start_date"):
+            raw.execute("ALTER TABLE chore ADD COLUMN start_date TEXT;")
+        if not _column_exists(raw, "chore", "end_date"):
+            raw.execute("ALTER TABLE chore ADD COLUMN end_date TEXT;")
+        if not _column_exists(raw, "choreinstance", "paid_event_id"):
+            raw.execute("ALTER TABLE choreinstance ADD COLUMN paid_event_id INTEGER;")
+        if not _column_exists(raw, "choreinstance", "created_at"):
+            raw.execute("ALTER TABLE choreinstance ADD COLUMN created_at TEXT;")
+        if not _column_exists(raw, "goal", "achieved_at"):
+            raw.execute("ALTER TABLE goal ADD COLUMN achieved_at TEXT;")
+        if not _column_exists(raw, "chore", "max_claimants"):
+            raw.execute("ALTER TABLE chore ADD COLUMN max_claimants INTEGER DEFAULT 1;")
+        if not _column_exists(raw, "chore", "weekdays"):
+            raw.execute("ALTER TABLE chore ADD COLUMN weekdays TEXT;")
+        if not _column_exists(raw, "chore", "specific_dates"):
+            raw.execute("ALTER TABLE chore ADD COLUMN specific_dates TEXT;")
+        if not _column_exists(raw, "certificate", "term_days"):
+            raw.execute("ALTER TABLE certificate ADD COLUMN term_days INTEGER DEFAULT 0;")
+            raw.execute(
+                """
+                UPDATE certificate
+                SET term_days = (
+                    CASE
+                        WHEN term_months IS NULL OR term_months < 0 THEN 0
+                        ELSE term_months * 30
+                    END
+                )
+                WHERE IFNULL(term_days, 0) = 0;
+                """
+            )
+        if not _column_exists(raw, "certificate", "penalty_days"):
+            raw.execute("ALTER TABLE certificate ADD COLUMN penalty_days INTEGER DEFAULT 0;")
+        raw.execute(
+            """
+            CREATE TABLE IF NOT EXISTS investment (
+                id INTEGER PRIMARY KEY,
+                kid_id TEXT,
+                fund TEXT,
+                shares REAL
+            );
+            """
+        )
+        raw.execute(
+            """
+            CREATE TABLE IF NOT EXISTS certificate (
+                id INTEGER PRIMARY KEY,
+                kid_id TEXT,
+                principal_cents INTEGER,
+                rate_bps INTEGER,
+                term_months INTEGER,
+                term_days INTEGER DEFAULT 0,
+                opened_at TEXT,
+                matured_at TEXT,
+                penalty_days INTEGER DEFAULT 0
+            );
+            """
+        )
+        raw.execute(
+            """
+            CREATE TABLE IF NOT EXISTS investmenttx (
+                id INTEGER PRIMARY KEY,
+                kid_id TEXT,
+                fund TEXT,
+                ts TEXT,
+                tx_type TEXT,
+                shares REAL,
+                price_cents INTEGER,
+                amount_cents INTEGER,
+                realized_pl_cents INTEGER
+            );
+            """
+        )
+        raw.execute(
+            """
+            CREATE TABLE IF NOT EXISTS marketinstrument (
+                id INTEGER PRIMARY KEY,
+                symbol TEXT,
+                name TEXT,
+                kind TEXT,
+                created_at TEXT
+            );
+            """
+        )
+        raw.execute(
+            """
+            CREATE TABLE IF NOT EXISTS kidmarketinstrument (
+                id INTEGER PRIMARY KEY,
+                kid_id TEXT,
+                symbol TEXT,
+                created_at TEXT
+            );
+            """
+        )
+        raw.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_kidmarketinstrument_kid_symbol
+            ON kidmarketinstrument(kid_id, symbol);
+            """
+        )
+        raw.execute(
+            """
+            INSERT OR IGNORE INTO kidmarketinstrument (kid_id, symbol, created_at)
+            SELECT DISTINCT kid_id, UPPER(fund), CURRENT_TIMESTAMP
+            FROM investment
+            WHERE IFNULL(kid_id, '') != '' AND IFNULL(fund, '') != '';
+            """
+        )
+        raw.execute(
+            """
+            CREATE TABLE IF NOT EXISTS globalchoreclaim (
+                id INTEGER PRIMARY KEY,
+                chore_id INTEGER,
+                kid_id TEXT,
+                period_key TEXT,
+                status TEXT,
+                award_cents INTEGER,
+                submitted_at TEXT,
+                approved_at TEXT,
+                approved_by TEXT,
+                notes TEXT
+            );
+            """
+        )
+        raw.execute(
+            """
+            CREATE TABLE IF NOT EXISTS lesson (
+                id INTEGER PRIMARY KEY,
+                title TEXT,
+                content_md TEXT,
+                summary TEXT,
+                created_at TEXT
+            );
+            """
+        )
+        raw.execute(
+            """
+            CREATE TABLE IF NOT EXISTS quiz (
+                id INTEGER PRIMARY KEY,
+                lesson_id INTEGER,
+                payload TEXT,
+                reward_cents INTEGER DEFAULT 0,
+                created_at TEXT
+            );
+            """
+        )
+        raw.execute(
+            """
+            CREATE TABLE IF NOT EXISTS quizattempt (
+                id INTEGER PRIMARY KEY,
+                child_id TEXT,
+                quiz_id INTEGER,
+                score INTEGER,
+                max_score INTEGER,
+                responses TEXT,
+                created_at TEXT
+            );
+            """
+        )
+        raw.execute(
+            """
+            CREATE TABLE IF NOT EXISTS marketplacelisting (
+                id INTEGER PRIMARY KEY,
+                owner_kid_id TEXT,
+                chore_id INTEGER,
+                chore_name TEXT,
+                chore_award_cents INTEGER,
+                offer_cents INTEGER,
+                status TEXT,
+                claimed_by TEXT,
+                created_at TEXT,
+                claimed_at TEXT,
+                submitted_at TEXT,
+                completed_at TEXT,
+                cancelled_at TEXT,
+                final_payout_cents INTEGER,
+                payout_note TEXT,
+                resolved_by TEXT,
+                payout_event_id INTEGER
+
+            );
+            """
+        )
+        raw.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_marketplace_owner_status
+            ON marketplacelisting(owner_kid_id, status);
+            """
+        )
+        raw.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_marketplace_status
+            ON marketplacelisting(status);
+            """
+        )
+
+        if not _column_exists(raw, "marketplacelisting", "submitted_at"):
+            raw.execute(
+                "ALTER TABLE marketplacelisting ADD COLUMN submitted_at TEXT;"
+            )
+        if not _column_exists(raw, "marketplacelisting", "final_payout_cents"):
+            raw.execute(
+                "ALTER TABLE marketplacelisting ADD COLUMN final_payout_cents INTEGER;"
+            )
+        if not _column_exists(raw, "marketplacelisting", "payout_note"):
+            raw.execute(
+                "ALTER TABLE marketplacelisting ADD COLUMN payout_note TEXT;"
+            )
+        if not _column_exists(raw, "marketplacelisting", "resolved_by"):
+            raw.execute(
+                "ALTER TABLE marketplacelisting ADD COLUMN resolved_by TEXT;"
+            )
+        if not _column_exists(raw, "marketplacelisting", "payout_event_id"):
+            raw.execute(
+                "ALTER TABLE marketplacelisting ADD COLUMN payout_event_id INTEGER;"
+            )
+
+        raw.commit()
+    finally:
+        raw.close()
+
+
+create_db_and_tables()
+run_migrations()
+
+
+
+
+__all__ = [
+    "engine",
+    "Child",
+    "Event",
+    "MoneyRequest",
+    "Prize",
+    "ChoreType",
+    "Chore",
+    "ChoreInstance",
+    "CHORE_STATUS_PENDING_MARKETPLACE",
+    "MARKETPLACE_STATUS_OPEN",
+    "MARKETPLACE_STATUS_CLAIMED",
+    "MARKETPLACE_STATUS_SUBMITTED",
+    "MARKETPLACE_STATUS_COMPLETED",
+    "MARKETPLACE_STATUS_CANCELLED",
+    "MARKETPLACE_STATUS_REJECTED",
+    "MarketplaceListing",
+    "MetaKV",
+    "Goal",
+    "Certificate",
+    "Investment",
+    "InvestmentTx",
+    "MarketInstrument",
+    "KidMarketInstrument",
+    "GlobalChoreClaim",
+    "Lesson",
+    "Quiz",
+    "QuizAttempt",
+    "GLOBAL_CHORE_KID_ID",
+    "GLOBAL_CHORE_STATUS_PENDING",
+    "GLOBAL_CHORE_STATUS_APPROVED",
+    "GLOBAL_CHORE_STATUS_REJECTED",
+    "INSTRUMENT_KIND_STOCK",
+    "INSTRUMENT_KIND_CRYPTO",
+    "DEFAULT_MARKET_SYMBOL",
+    "TIME_MODE_AUTO",
+    "TIME_MODE_MANUAL",
+    "TIME_META_MODE_KEY",
+    "TIME_META_MANUAL_KEY",
+    "TIME_META_OFFSET_KEY",
+    "TIME_META_MANUAL_REF_KEY",
+    "create_db_and_tables",
+    "run_migrations"
+]


### PR DESCRIPTION
## Summary
- add a requirements-web.txt bundle and document how to install the optional FastAPI stack
- split the web frontend into a package with configuration, persistence, and application modules guarded by optional dependency handling
- re-export the SQLModel entities and helpers while lazily importing the FastAPI application for better optional-dependency support

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d544749c94832e8ec56a2056e88874