### PR TITLE
Expose webapp persistence exports in package

### DIFF
--- a/src/kidbank/webapp/__init__.py
+++ b/src/kidbank/webapp/__init__.py
@@ -10,14 +10,27 @@ _IMPL_MODULE: ModuleType | None = None
 
 _OPTIONAL_MODULES = {"fastapi", "starlette", "sqlmodel", "sqlalchemy", "dotenv"}
 
+try:
+    from . import persistence as _persistence
+except ModuleNotFoundError as exc:  # pragma: no cover - defensive guard
+    if exc.name in _OPTIONAL_MODULES:
+        _OPTIONAL_IMPORT_ERROR = exc
+        raise RuntimeError(
+            "kidbank.webapp requires optional FastAPI/SQLModel dependencies. "
+            "Install them via `pip install -r requirements-web.txt` or the web extra."
+        ) from exc
+    raise
+
+persistence = _persistence
+__all__: List[str] = list(getattr(_persistence, "__all__", ()))
+
 
 def _load_impl() -> ModuleType:
     global _IMPL_MODULE, _OPTIONAL_IMPORT_ERROR
     if _IMPL_MODULE is not None:
         return _IMPL_MODULE
     try:
-        _IMPL_MODULE = import_module(".application", __name__)
-        return _IMPL_MODULE
+        module = import_module(".application", __name__)
     except ModuleNotFoundError as exc:  # pragma: no cover - defensive guard
         if exc.name in _OPTIONAL_MODULES:
             _OPTIONAL_IMPORT_ERROR = exc
@@ -26,17 +39,24 @@ def _load_impl() -> ModuleType:
                 "Install them via `pip install -r requirements-web.txt` or the web extra."
             ) from exc
         raise
+    _IMPL_MODULE = module
+    module_all = getattr(module, "__all__", ())
+    __all__.extend(name for name in module_all if name not in __all__)
+    return module
 
 
 def __getattr__(name: str) -> Any:
+    if hasattr(_persistence, name):
+        return getattr(_persistence, name)
     module = _load_impl()
     return getattr(module, name)
 
 
 def __dir__() -> List[str]:
+    names = set(globals()) | set(__all__)
     try:
         module = _load_impl()
     except RuntimeError:
-        return sorted(list(globals().keys()))
-    return sorted(set(globals()) | set(dir(module)))
+        return sorted(names)
+    return sorted(names | set(dir(module)))
 


### PR DESCRIPTION
## Summary
- import the persistence module in `kidbank.webapp` and expose its exports through `__all__`
- fall back to the FastAPI application module for additional attributes while keeping optional dependency handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d54a4bdcd0832e9b6ae36026a60b3c