### PR TITLE
Add special chore guardrails and admin chore deletion

### DIFF
--- a/src/kidbank/webapp/application.py
+++ b/src/kidbank/webapp/application.py
@@ -31,8 +31,8 @@ from urllib.request import Request as URLRequest, urlopen
 
 from fastapi import FastAPI, Form, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse, JSONResponse, Response
-from sqlalchemy import inspect
-from sqlmodel import Session, desc, select, delete
+from sqlalchemy import delete, inspect
+from sqlmodel import Session, desc, select
 from starlette.middleware.sessions import SessionMiddleware
 
 from .config import (

--- a/src/kidbank/webapp/application.py
+++ b/src/kidbank/webapp/application.py
@@ -5790,7 +5790,7 @@ def _kid_invest_dashboard_inner(
         chart=CHART_VIEW_DETAIL,
     )
     chart_toggle_html = (
-        "<div class='chart-toggle'>Chart: ""
+        "<div class='chart-toggle'>Chart: "
         + f"<a href='{compact_url}' class='{'active' if chart_mode == CHART_VIEW_COMPACT else ''}'>Compact</a>"
         + f"<a href='{detail_url}' class='{'active' if chart_mode == CHART_VIEW_DETAIL else ''}'>Detailed</a>"
         + "</div>"


### PR DESCRIPTION
## Summary
- enforce a once-per-day limit for scheduled special chores and ensure the investing tracker redirects through the new kiosk embedding flow
- surface the approving admin in the Free-for-all history table and adjust the manage chores navigation buttons
- add delete controls for chores in the admin portal along with backend cleanup for related instances and claims

## Testing
- pytest *(fails: optional FastAPI/SQLModel web dependencies are not installed in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70e26c9cc832e9ec1d0198fc571d8