### PR TITLE
Fix mobile calendar layout

### DIFF
--- a/src/kidbank/webapp/application.py
+++ b/src/kidbank/webapp/application.py
@@ -938,6 +938,19 @@ def base_styles() -> str:
         td[data-label="Actions"] .right{ text-align:left; }
         td[data-label="Actions"] form,
         td[data-label="Actions"] a{ display:block; width:100%; margin:6px 0 0 0; }
+        .calendar-table,
+        .calendar-table thead,
+        .calendar-table tbody,
+        .calendar-table tr,
+        .calendar-table th,
+        .calendar-table td{ display:table; width:auto; }
+        .calendar-table{ width:100%; }
+        .calendar-table thead{ display:table-header-group; }
+        .calendar-table tbody{ display:table-row-group; }
+        .calendar-table tr{ display:table-row; margin:0; border:none; padding:0; background:transparent; }
+        .calendar-table th,
+        .calendar-table td{ display:table-cell; border:none; padding:6px 4px; position:static; text-align:center !important; white-space:normal; }
+        .calendar-table td::before{ content:none; }
         td[data-label="Actions"] button{ width:100%; }
         .chore-row__actions{align-items:stretch;}
         .chore-row__actions form{justify-content:stretch;}


### PR DESCRIPTION
## Summary
- override the mobile responsive table styles for the chores calendar so it keeps its grid layout on phones
- ensure calendar table headers and cells restore their original display while other tables remain responsive

## Testing
- pytest *(fails: missing optional FastAPI/SQLModel and Starlette dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d74eac1fc8832e8ad1a5327fb21386